### PR TITLE
Gemini TTS: Provider, Settings und Synthese-Endpoint

### DIFF
--- a/Frontend/app/page.js
+++ b/Frontend/app/page.js
@@ -17,7 +17,6 @@ const SIDEBAR_COLLAPSED_KEY = 'mynd_sidebar_collapsed_v1';
 const DISPLAY_NAME_STORAGE_KEY = 'mynd_display_name';
 const LOCATION_AUTO_RESOLVE_KEY = 'mynd_location_auto_resolve_v1';
 const BRIEFING_SEEN_KEY = 'mynd_seen_briefings_v1';
-const VOICE_SELECTION_STORAGE_KEY = 'mynd_voice_selection_v1';
 
 const SPEECH_LANG_MAP = {
   de: 'de-DE',
@@ -196,6 +195,7 @@ export default function HomePage() {
   const [voiceError, setVoiceError] = useState('');
   const [speechCapabilities, setSpeechCapabilities] = useState({ input: false, output: false });
   const [selectedVoiceUri, setSelectedVoiceUri] = useState('');
+  const [ttsProvider, setTtsProvider] = useState('browser');
   
   const [aiProtocol, setAiProtocol] = useState('http');
   const [aiHost, setAiHost] = useState('127.0.0.1');
@@ -286,6 +286,7 @@ export default function HomePage() {
   const progressIntervalRef = useRef(null);
   const requestAbortRef = useRef(null);
   const speechRecognitionRef = useRef(null);
+  const activeAudioRef = useRef(null);
   
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
@@ -615,11 +616,6 @@ export default function HomePage() {
         setDisplayName(rawDisplayName);
       }
 
-      const storedVoiceSelection = localStorage.getItem(VOICE_SELECTION_STORAGE_KEY);
-      if (storedVoiceSelection) {
-        setSelectedVoiceUri(storedVoiceSelection);
-      }
-
       const rawChats = localStorage.getItem(CHAT_STORAGE_KEY);
       const rawActiveChatId = localStorage.getItem(ACTIVE_CHAT_STORAGE_KEY);
       const rawSidebarCollapsed = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
@@ -670,14 +666,6 @@ export default function HomePage() {
       console.error('Error saving sidebar state:', err);
     }
   }, [isSidebarCollapsed]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(VOICE_SELECTION_STORAGE_KEY, selectedVoiceUri || '');
-    } catch (err) {
-      console.error('Error saving voice selection:', err);
-    }
-  }, [selectedVoiceUri]);
 
   useEffect(() => {
     if (!photoPreview.open) return undefined;
@@ -791,6 +779,8 @@ export default function HomePage() {
       setAiHost(url.hostname);
       setAiPort(url.port || '11434');
       setAiModel(config.model);
+      setTtsProvider(String(config.tts_provider || 'browser').toLowerCase() === 'gemini' ? 'gemini' : 'browser');
+      setSelectedVoiceUri(String(config.browser_tts_voice_uri || ''));
       setAiStatus('Loaded');
     } catch (err) {
       setAiStatus('Error loading config');
@@ -1215,48 +1205,123 @@ export default function HomePage() {
   };
 
   const speakAssistantText = (text) => {
-    if (!speechSynthesisSupported) return;
     const prepared = cleanTextForSpeech(text).slice(0, 1100);
     if (!prepared) return;
 
-    try {
-      window.speechSynthesis.cancel();
-      const utterance = new window.SpeechSynthesisUtterance(prepared);
-      const locale = resolveSpeechLocale(language);
-      utterance.lang = locale;
-      utterance.rate = 1;
-      utterance.pitch = 1;
-
-      const browserVoices = window.speechSynthesis.getVoices();
-      const selectedVoice = selectedVoiceUri
-        ? browserVoices.find((voice) => voice.voiceURI === selectedVoiceUri)
-        : null;
-      const matchingVoice = selectedVoice
-        || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(language.toLowerCase()))
-        || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(locale.slice(0, 2).toLowerCase()));
-
-      if (matchingVoice) {
-        utterance.voice = matchingVoice;
+    const stopAudioPlayback = () => {
+      const activeAudio = activeAudioRef.current;
+      if (activeAudio) {
+        try {
+          activeAudio.pause();
+        } catch (_) {
+          // ignore pause errors from stale audio instances
+        }
+        activeAudioRef.current = null;
       }
+    };
 
-      utterance.onstart = () => {
-        setIsSpeaking(true);
-      };
+    const speakWithBrowser = () => {
+      if (!speechSynthesisSupported) return;
 
-      utterance.onend = () => {
+      try {
+        stopAudioPlayback();
+        window.speechSynthesis.cancel();
+        const utterance = new window.SpeechSynthesisUtterance(prepared);
+        const locale = resolveSpeechLocale(language);
+        utterance.lang = locale;
+        utterance.rate = 1;
+        utterance.pitch = 1;
+
+        const browserVoices = window.speechSynthesis.getVoices();
+        const selectedVoice = selectedVoiceUri
+          ? browserVoices.find((voice) => voice.voiceURI === selectedVoiceUri)
+          : null;
+        const matchingVoice = selectedVoice
+          || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(language.toLowerCase()))
+          || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(locale.slice(0, 2).toLowerCase()));
+
+        if (matchingVoice) {
+          utterance.voice = matchingVoice;
+        }
+
+        utterance.onstart = () => {
+          setIsSpeaking(true);
+        };
+
+        utterance.onend = () => {
+          setIsSpeaking(false);
+        };
+
+        utterance.onerror = () => {
+          setIsSpeaking(false);
+          setVoiceError(language === 'de' ? 'Sprachausgabe fehlgeschlagen.' : 'Text-to-speech failed.');
+        };
+
+        window.speechSynthesis.speak(utterance);
+      } catch (err) {
         setIsSpeaking(false);
-      };
+        setVoiceError(language === 'de' ? 'Sprachausgabe nicht verfuegbar.' : 'Text-to-speech is unavailable.');
+      }
+    };
 
-      utterance.onerror = () => {
-        setIsSpeaking(false);
-        setVoiceError(language === 'de' ? 'Sprachausgabe fehlgeschlagen.' : 'Text-to-speech failed.');
-      };
+    const speakWithGemini = async () => {
+      try {
+        stopAudioPlayback();
+        if (speechSynthesisSupported) {
+          window.speechSynthesis.cancel();
+        }
 
-      window.speechSynthesis.speak(utterance);
-    } catch (err) {
-      setIsSpeaking(false);
-      setVoiceError(language === 'de' ? 'Sprachausgabe nicht verfuegbar.' : 'Text-to-speech is unavailable.');
+        const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            text: prepared,
+            language_code: resolveSpeechLocale(language)
+          })
+        });
+        const data = await safeReadJson(response);
+
+        if (!response.ok || data?.success === false || !data?.audio_base64) {
+          throw new Error(data?.error || `Gemini TTS request failed (${response.status})`);
+        }
+
+        const mimeType = data?.mime_type || 'audio/mpeg';
+        const audio = new Audio(`data:${mimeType};base64,${data.audio_base64}`);
+        activeAudioRef.current = audio;
+
+        audio.onplay = () => {
+          setIsSpeaking(true);
+          setVoiceError('');
+        };
+        audio.onended = () => {
+          setIsSpeaking(false);
+          if (activeAudioRef.current === audio) {
+            activeAudioRef.current = null;
+          }
+        };
+        audio.onerror = () => {
+          setIsSpeaking(false);
+          if (activeAudioRef.current === audio) {
+            activeAudioRef.current = null;
+          }
+          setVoiceError(language === 'de' ? 'Gemini-Audio konnte nicht abgespielt werden.' : 'Gemini audio playback failed.');
+        };
+
+        await audio.play();
+      } catch (err) {
+        setVoiceError(language === 'de'
+          ? `Gemini-TTS Fehler: ${err.message}. Fallback auf Browser-Stimme.`
+          : `Gemini TTS error: ${err.message}. Falling back to browser voice.`);
+        speakWithBrowser();
+      }
+    };
+
+    if (ttsProvider === 'gemini') {
+      speakWithGemini();
+      return;
     }
+
+    speakWithBrowser();
   };
 
   const startVoiceInput = () => {
@@ -1333,11 +1398,19 @@ export default function HomePage() {
         speechRecognitionRef.current.stop();
         speechRecognitionRef.current = null;
       }
+      if (activeAudioRef.current) {
+        try {
+          activeAudioRef.current.pause();
+        } catch (_) {
+          // ignore pause errors from stale audio instances
+        }
+        activeAudioRef.current = null;
+      }
       if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
         window.speechSynthesis.cancel();
       }
     };
-  }, []);
+  }, [speechSynthesisSupported]);
 
   const parseBackendDateTimeToInput = (value) => {
     if (!value || typeof value !== 'string') return '';

--- a/Frontend/app/settings/page.js
+++ b/Frontend/app/settings/page.js
@@ -9,7 +9,6 @@ import { ThemeSelector } from '../../components/ThemeSelector';
 const API_BASE = '';
 const SIDEBAR_COLLAPSED_KEY = 'mynd_sidebar_collapsed_v1';
 const DISPLAY_NAME_STORAGE_KEY = 'mynd_display_name';
-const VOICE_SELECTION_STORAGE_KEY = 'mynd_voice_selection_v1';
 const API_DISPLAY_NAMES = {
   immich: 'Immich',
   homeassistant: 'Home Assistant',
@@ -184,6 +183,14 @@ export default function SettingsPage() {
   const [speechSynthesisSupported, setSpeechSynthesisSupported] = useState(false);
   const [availableVoices, setAvailableVoices] = useState([]);
   const [selectedVoiceUri, setSelectedVoiceUri] = useState('');
+  const [ttsProvider, setTtsProvider] = useState('browser');
+  const [geminiTtsModel, setGeminiTtsModel] = useState('gemini-2.5-flash-tts');
+  const [geminiTtsVoice, setGeminiTtsVoice] = useState('Kore');
+  const [geminiTtsLanguageCode, setGeminiTtsLanguageCode] = useState('de-DE');
+  const [geminiTtsStylePrompt, setGeminiTtsStylePrompt] = useState('');
+  const [geminiTtsAudioEncoding, setGeminiTtsAudioEncoding] = useState('MP3');
+  const [geminiTtsApiKey, setGeminiTtsApiKey] = useState('');
+  const [geminiTtsApiKeySet, setGeminiTtsApiKeySet] = useState(false);
   
   const [aiProtocol, setAiProtocol] = useState('http');
   const [aiHost, setAiHost] = useState('127.0.0.1');
@@ -285,6 +292,11 @@ export default function SettingsPage() {
   const visibleVoices = language === 'de'
     ? availableVoices.filter((voice) => String(voice.lang || '').toLowerCase().startsWith('de'))
     : availableVoices;
+  const geminiVoices = [
+    'Achernar', 'Achird', 'Algenib', 'Algieba', 'Alnilam', 'Aoede', 'Autonoe', 'Callirrhoe', 'Charon', 'Despina',
+    'Enceladus', 'Erinome', 'Fenrir', 'Gacrux', 'Iapetus', 'Kore', 'Laomedeia', 'Leda', 'Orus', 'Pulcherrima',
+    'Puck', 'Rasalgethi', 'Sadachbia', 'Sadaltager', 'Schedar', 'Sulafat', 'Umbriel', 'Vindemiatrix', 'Zephyr', 'Zubenelgenubi'
+  ];
 
   useEffect(() => {
     loadAIConfig();
@@ -342,15 +354,6 @@ export default function SettingsPage() {
     const supportsSynthesis = 'speechSynthesis' in window && typeof window.SpeechSynthesisUtterance !== 'undefined';
     setSpeechSynthesisSupported(supportsSynthesis);
 
-    try {
-      const storedVoice = localStorage.getItem(VOICE_SELECTION_STORAGE_KEY);
-      if (storedVoice) {
-        setSelectedVoiceUri(storedVoice);
-      }
-    } catch (err) {
-      console.error('Error loading selected voice:', err);
-    }
-
     if (!supportsSynthesis) return;
 
     const updateVoices = () => {
@@ -370,14 +373,6 @@ export default function SettingsPage() {
       window.speechSynthesis.removeEventListener('voiceschanged', updateVoices);
     };
   }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(VOICE_SELECTION_STORAGE_KEY, selectedVoiceUri || '');
-    } catch (err) {
-      console.error('Error saving selected voice:', err);
-    }
-  }, [selectedVoiceUri]);
 
   useEffect(() => {
     if (!selectedVoiceUri) return;
@@ -601,6 +596,15 @@ export default function SettingsPage() {
       setAiHost(url.hostname);
       setAiPort(url.port || '11434');
       setAiModel(config.model);
+      setTtsProvider(String(config.tts_provider || 'browser').toLowerCase() === 'gemini' ? 'gemini' : 'browser');
+      setSelectedVoiceUri(String(config.browser_tts_voice_uri || ''));
+      setGeminiTtsModel(String(config.gemini_tts_model || 'gemini-2.5-flash-tts'));
+      setGeminiTtsVoice(String(config.gemini_tts_voice || 'Kore'));
+      setGeminiTtsLanguageCode(String(config.gemini_tts_language_code || 'de-DE'));
+      setGeminiTtsStylePrompt(String(config.gemini_tts_style_prompt || ''));
+      setGeminiTtsAudioEncoding(String(config.gemini_tts_audio_encoding || 'MP3'));
+      setGeminiTtsApiKeySet(Boolean(config.gemini_tts_api_key_set));
+      setGeminiTtsApiKey('');
       setAiStatus(tr('Geladen', 'Loaded'));
     } catch (err) {
       setAiStatus(tr('Fehler beim Laden der Konfiguration', 'Error loading config'));
@@ -712,16 +716,35 @@ export default function SettingsPage() {
   const saveAIConfig = async () => {
     try {
       const baseUrl = `${aiProtocol}://${aiHost}:${aiPort}`;
+      const payload = {
+        base_url: baseUrl,
+        model: aiModel,
+        tts_provider: ttsProvider,
+        browser_tts_voice_uri: selectedVoiceUri,
+        gemini_tts_model: geminiTtsModel,
+        gemini_tts_voice: geminiTtsVoice,
+        gemini_tts_language_code: geminiTtsLanguageCode,
+        gemini_tts_style_prompt: geminiTtsStylePrompt,
+        gemini_tts_audio_encoding: geminiTtsAudioEncoding
+      };
+
+      if (geminiTtsApiKey.trim()) {
+        payload.gemini_tts_api_key = geminiTtsApiKey.trim();
+      }
+
       const res = await fetch(`${API_BASE}/api/ai/config`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ base_url: baseUrl, model: aiModel })
+        body: JSON.stringify(payload)
       });
+      const data = await res.json();
       if (res.ok) {
         setAiStatus(tr('Erfolgreich gespeichert', 'Saved successfully'));
+        setGeminiTtsApiKey('');
+        setGeminiTtsApiKeySet(Boolean(data?.gemini_tts_api_key_set || geminiTtsApiKeySet || geminiTtsApiKey.trim()));
         updateStatus();
       } else {
-        setAiStatus(tr('Fehler beim Speichern', 'Error saving'));
+        setAiStatus(`Error: ${data?.error || tr('Fehler beim Speichern', 'Error saving')}`);
       }
     } catch (err) {
       setAiStatus('Error: ' + err.message);
@@ -1407,6 +1430,99 @@ export default function SettingsPage() {
                     <button className="btn primary" onClick={saveAIConfig}>{t('save')}</button>
                   </div>
                   {aiStatus && <div className="status-text">{aiStatus}</div>}
+                </div>
+
+                <div className="panel-section" style={{marginTop: '2rem'}}>
+                  <div className="section-title">Gemini TTS</div>
+                  <div className="input-group">
+                    <label>{tr('TTS-Anbieter', 'TTS Provider')}</label>
+                    <select value={ttsProvider} onChange={(e) => setTtsProvider(e.target.value)}>
+                      <option value="browser">{tr('Browser (lokal)', 'Browser (local)')}</option>
+                      <option value="gemini">Gemini TTS</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Browser-Stimme', 'Browser Voice')}</label>
+                    {speechSynthesisSupported ? (
+                      <>
+                        <select value={selectedVoiceUri} onChange={(e) => setSelectedVoiceUri(e.target.value)}>
+                          <option value="">{tr('Automatische Stimme', 'Automatic voice')}</option>
+                          {visibleVoices.map((voice) => (
+                            <option key={voice.voiceURI} value={voice.voiceURI}>
+                              {formatVoiceLabel(voice)}
+                            </option>
+                          ))}
+                        </select>
+                        {language === 'de' && (
+                          <div className="status-text">{tr('Bei deutscher Sprache werden nur deutsche Stimmen angeboten.', 'Only German voices are shown for German language.')}</div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="status-text">{tr('Sprachausgabe wird von diesem Browser nicht unterstuetzt.', 'Speech synthesis is not supported in this browser.')}</div>
+                    )}
+                  </div>
+
+                  <div className="input-group">
+                    <label>Gemini API Key</label>
+                    <input
+                      type="password"
+                      value={geminiTtsApiKey}
+                      onChange={(e) => setGeminiTtsApiKey(e.target.value)}
+                      placeholder={geminiTtsApiKeySet ? tr('Bereits gesetzt (neu eingeben zum Ueberschreiben)', 'Already set (enter new key to overwrite)') : 'AIza...'}
+                    />
+                    {geminiTtsApiKeySet && !geminiTtsApiKey.trim() && (
+                      <div className="status-text">{tr('API Key ist gesetzt.', 'API key is set.')}</div>
+                    )}
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Modell', 'Gemini Model')}</label>
+                    <select value={geminiTtsModel} onChange={(e) => setGeminiTtsModel(e.target.value)}>
+                      <option value="gemini-2.5-flash-tts">gemini-2.5-flash-tts</option>
+                      <option value="gemini-2.5-pro-tts">gemini-2.5-pro-tts</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Stimme', 'Gemini Voice')}</label>
+                    <select value={geminiTtsVoice} onChange={(e) => setGeminiTtsVoice(e.target.value)}>
+                      {geminiVoices.map((voiceName) => (
+                        <option key={voiceName} value={voiceName}>{voiceName}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Sprache (BCP-47)', 'Gemini Language (BCP-47)')}</label>
+                    <input type="text" value={geminiTtsLanguageCode} onChange={(e) => setGeminiTtsLanguageCode(e.target.value)} placeholder="de-DE" />
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Audio-Format', 'Audio Encoding')}</label>
+                    <select value={geminiTtsAudioEncoding} onChange={(e) => setGeminiTtsAudioEncoding(e.target.value)}>
+                      <option value="MP3">MP3</option>
+                      <option value="LINEAR16">LINEAR16</option>
+                      <option value="OGG_OPUS">OGG_OPUS</option>
+                      <option value="MULAW">MULAW</option>
+                      <option value="ALAW">ALAW</option>
+                      <option value="PCM">PCM</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Stil-Prompt (optional)', 'Style Prompt (optional)')}</label>
+                    <input
+                      type="text"
+                      value={geminiTtsStylePrompt}
+                      onChange={(e) => setGeminiTtsStylePrompt(e.target.value)}
+                      placeholder={tr('z.B. Sprich ruhig und freundlich', 'e.g. Speak in a calm and friendly tone')}
+                    />
+                  </div>
+
+                  <div className="button-group">
+                    <button className="btn primary" onClick={saveAIConfig}>{t('save')}</button>
+                  </div>
                 </div>
 
                 <div className="panel-section" style={{marginTop: '2rem'}}>
@@ -2297,29 +2413,6 @@ export default function SettingsPage() {
                       <option key={entry.code} value={entry.code}>{entry.label}</option>
                     ))}
                   </select>
-                </div>
-                <div className="input-group" style={{ marginBottom: '1rem' }}>
-                  <label>{tr('Stimme', 'Voice')}</label>
-                  {speechSynthesisSupported ? (
-                    <>
-                      <select value={selectedVoiceUri} onChange={(e) => setSelectedVoiceUri(e.target.value)}>
-                        <option value="">{tr('Automatische Stimme', 'Automatic voice')}</option>
-                        {visibleVoices.map((voice) => (
-                          <option key={voice.voiceURI} value={voice.voiceURI}>
-                            {formatVoiceLabel(voice)}
-                          </option>
-                        ))}
-                      </select>
-                      {language === 'de' && (
-                        <div className="status-text">{tr('Bei deutscher Sprache werden nur deutsche Stimmen angeboten.', 'Only German voices are shown for German language.')}</div>
-                      )}
-                      {language === 'de' && visibleVoices.length === 0 && (
-                        <div className="status-text">{tr('Keine deutschen Stimmen im Browser gefunden. Bitte installiere eine deutsche Systemstimme.', 'No German voices found in the browser. Please install a German system voice.')}</div>
-                      )}
-                    </>
-                  ) : (
-                    <div className="status-text">{tr('Sprachausgabe wird von diesem Browser nicht unterstuetzt.', 'Speech synthesis is not supported in this browser.')}</div>
-                  )}
                 </div>
                 <ThemeSelector
                   currentTheme={theme}

--- a/backend/core/app.py
+++ b/backend/core/app.py
@@ -1264,6 +1264,14 @@ def load_ai_config() -> dict:
         'briefing_daily_enabled': BRIEFING_DAILY_ENABLED_DEFAULT,
         'briefing_weekly_enabled': BRIEFING_WEEKLY_ENABLED_DEFAULT,
         'briefing_morning_hour': int(BRIEFING_MORNING_HOUR),
+        'tts_provider': 'browser',
+        'browser_tts_voice_uri': '',
+        'gemini_tts_api_key': '',
+        'gemini_tts_model': 'gemini-2.5-flash-tts',
+        'gemini_tts_voice': 'Kore',
+        'gemini_tts_language_code': 'de-DE',
+        'gemini_tts_style_prompt': '',
+        'gemini_tts_audio_encoding': 'MP3',
     }
 
     if os.path.exists(AI_CONFIG_FILE):
@@ -1284,6 +1292,16 @@ def load_ai_config() -> dict:
             config['briefing_daily_enabled'] = bool(file_config.get('briefing_daily_enabled', config['briefing_daily_enabled']))
             config['briefing_weekly_enabled'] = bool(file_config.get('briefing_weekly_enabled', config['briefing_weekly_enabled']))
             config['briefing_morning_hour'] = max(0, min(23, int(file_config.get('briefing_morning_hour', config['briefing_morning_hour']))))
+            config['tts_provider'] = str(file_config.get('tts_provider', config['tts_provider'])).strip().lower() or 'browser'
+            if config['tts_provider'] not in ('browser', 'gemini'):
+                config['tts_provider'] = 'browser'
+            config['browser_tts_voice_uri'] = str(file_config.get('browser_tts_voice_uri', config['browser_tts_voice_uri'])).strip()
+            config['gemini_tts_api_key'] = str(file_config.get('gemini_tts_api_key', config['gemini_tts_api_key'])).strip()
+            config['gemini_tts_model'] = str(file_config.get('gemini_tts_model', config['gemini_tts_model'])).strip() or 'gemini-2.5-flash-tts'
+            config['gemini_tts_voice'] = str(file_config.get('gemini_tts_voice', config['gemini_tts_voice'])).strip() or 'Kore'
+            config['gemini_tts_language_code'] = str(file_config.get('gemini_tts_language_code', config['gemini_tts_language_code'])).strip() or 'de-DE'
+            config['gemini_tts_style_prompt'] = str(file_config.get('gemini_tts_style_prompt', config['gemini_tts_style_prompt'])).strip()
+            config['gemini_tts_audio_encoding'] = str(file_config.get('gemini_tts_audio_encoding', config['gemini_tts_audio_encoding'])).strip().upper() or 'MP3'
         except Exception as e:
             logger.warning(f"Konnte AI-Konfiguration nicht laden: {str(e)}")
 
@@ -1291,7 +1309,7 @@ def load_ai_config() -> dict:
     return config
 
 
-def save_ai_config(base_url: str, model: str) -> None:
+def save_ai_config(base_url: str, model: str, **overrides: Any) -> None:
     """Speichert AI-Konfiguration persistent in einer lokalen JSON-Datei."""
     config = {}
     if os.path.exists(AI_CONFIG_FILE):
@@ -1304,6 +1322,20 @@ def save_ai_config(base_url: str, model: str) -> None:
     config['provider'] = 'ollama'
     config['base_url'] = base_url.rstrip('/')
     config['model'] = model
+
+    allowed_overrides = {
+        'tts_provider',
+        'browser_tts_voice_uri',
+        'gemini_tts_api_key',
+        'gemini_tts_model',
+        'gemini_tts_voice',
+        'gemini_tts_language_code',
+        'gemini_tts_style_prompt',
+        'gemini_tts_audio_encoding',
+    }
+    for key, value in overrides.items():
+        if key in allowed_overrides:
+            config[key] = value
 
     with open(AI_CONFIG_FILE, 'w', encoding='utf-8') as f:
         json.dump(config, f, ensure_ascii=False, indent=2)
@@ -3826,11 +3858,20 @@ def ai_config():
     """Liest oder speichert die AI-Konfiguration (aktuell Ollama)."""
     try:
         if request.method == 'GET':
+            persisted = load_ai_config()
             return jsonify({
                 'provider': 'ollama',
                 'base_url': ollama_client.base_url,
                 'model': ollama_client.model,
-                'connected': ollama_client.check_connection()
+                'connected': ollama_client.check_connection(),
+                'tts_provider': persisted.get('tts_provider', 'browser'),
+                'browser_tts_voice_uri': persisted.get('browser_tts_voice_uri', ''),
+                'gemini_tts_model': persisted.get('gemini_tts_model', 'gemini-2.5-flash-tts'),
+                'gemini_tts_voice': persisted.get('gemini_tts_voice', 'Kore'),
+                'gemini_tts_language_code': persisted.get('gemini_tts_language_code', 'de-DE'),
+                'gemini_tts_style_prompt': persisted.get('gemini_tts_style_prompt', ''),
+                'gemini_tts_audio_encoding': persisted.get('gemini_tts_audio_encoding', 'MP3'),
+                'gemini_tts_api_key_set': bool(persisted.get('gemini_tts_api_key'))
             })
 
         data = request.json or {}
@@ -3843,15 +3884,50 @@ def ai_config():
         if not (base_url.startswith('http://') or base_url.startswith('https://')):
             return jsonify({'error': 'base_url muss mit http:// oder https:// beginnen'}), 400
 
+        tts_provider = str(data.get('tts_provider', 'browser')).strip().lower() or 'browser'
+        if tts_provider not in ('browser', 'gemini'):
+            return jsonify({'error': 'tts_provider muss browser oder gemini sein'}), 400
+
+        existing = load_ai_config()
+        gemini_tts_api_key = str(data.get('gemini_tts_api_key', '')).strip()
+        if not gemini_tts_api_key:
+            gemini_tts_api_key = str(existing.get('gemini_tts_api_key', '')).strip()
+
+        browser_tts_voice_uri = str(data.get('browser_tts_voice_uri', '')).strip()
+        gemini_tts_model = str(data.get('gemini_tts_model', existing.get('gemini_tts_model', 'gemini-2.5-flash-tts'))).strip() or 'gemini-2.5-flash-tts'
+        gemini_tts_voice = str(data.get('gemini_tts_voice', existing.get('gemini_tts_voice', 'Kore'))).strip() or 'Kore'
+        gemini_tts_language_code = str(data.get('gemini_tts_language_code', existing.get('gemini_tts_language_code', 'de-DE'))).strip() or 'de-DE'
+        gemini_tts_style_prompt = str(data.get('gemini_tts_style_prompt', existing.get('gemini_tts_style_prompt', ''))).strip()
+        gemini_tts_audio_encoding = str(data.get('gemini_tts_audio_encoding', existing.get('gemini_tts_audio_encoding', 'MP3'))).strip().upper() or 'MP3'
+
         ollama_client.update_config(base_url, model)
-        save_ai_config(base_url, model)
+        save_ai_config(
+            base_url,
+            model,
+            tts_provider=tts_provider,
+            browser_tts_voice_uri=browser_tts_voice_uri,
+            gemini_tts_api_key=gemini_tts_api_key,
+            gemini_tts_model=gemini_tts_model,
+            gemini_tts_voice=gemini_tts_voice,
+            gemini_tts_language_code=gemini_tts_language_code,
+            gemini_tts_style_prompt=gemini_tts_style_prompt,
+            gemini_tts_audio_encoding=gemini_tts_audio_encoding,
+        )
 
         return jsonify({
             'status': 'saved',
             'provider': 'ollama',
             'base_url': ollama_client.base_url,
             'model': ollama_client.model,
-            'connected': ollama_client.check_connection()
+            'connected': ollama_client.check_connection(),
+            'tts_provider': tts_provider,
+            'browser_tts_voice_uri': browser_tts_voice_uri,
+            'gemini_tts_model': gemini_tts_model,
+            'gemini_tts_voice': gemini_tts_voice,
+            'gemini_tts_language_code': gemini_tts_language_code,
+            'gemini_tts_style_prompt': gemini_tts_style_prompt,
+            'gemini_tts_audio_encoding': gemini_tts_audio_encoding,
+            'gemini_tts_api_key_set': bool(gemini_tts_api_key)
         })
     except Exception as e:
         return jsonify({'error': str(e)}), 500
@@ -3897,6 +3973,101 @@ def ai_test():
         })
     except Exception as e:
         return jsonify({'error': str(e)}), 500
+
+
+def _trim_utf8_bytes(value: str, max_bytes: int) -> str:
+    encoded = value.encode('utf-8')
+    if len(encoded) <= max_bytes:
+        return value
+    return encoded[:max_bytes].decode('utf-8', errors='ignore')
+
+
+@app.route('/api/tts/synthesize', methods=['POST'])
+def tts_synthesize():
+    """Synthetisiert Audio ueber Gemini TTS (Google Cloud Text-to-Speech API)."""
+    try:
+        data = request.json or {}
+        text = str(data.get('text', '')).strip()
+        if not text:
+            return jsonify({'success': False, 'error': 'text darf nicht leer sein'}), 400
+
+        config = load_ai_config()
+        tts_provider = str(config.get('tts_provider', 'browser')).strip().lower()
+        if tts_provider != 'gemini':
+            return jsonify({'success': False, 'error': 'tts_provider ist nicht auf gemini gesetzt'}), 400
+
+        api_key = str(config.get('gemini_tts_api_key', '')).strip()
+        if not api_key:
+            return jsonify({'success': False, 'error': 'Gemini TTS API Key ist nicht konfiguriert'}), 400
+
+        prompt = str(data.get('prompt', config.get('gemini_tts_style_prompt', ''))).strip()
+        text = _trim_utf8_bytes(text, 4000)
+        prompt = _trim_utf8_bytes(prompt, 4000)
+
+        combined_bytes = len(text.encode('utf-8')) + len(prompt.encode('utf-8'))
+        if combined_bytes > 8000:
+            allowed_prompt_bytes = max(0, 8000 - len(text.encode('utf-8')))
+            prompt = _trim_utf8_bytes(prompt, allowed_prompt_bytes)
+
+        model_name = str(data.get('model', config.get('gemini_tts_model', 'gemini-2.5-flash-tts'))).strip() or 'gemini-2.5-flash-tts'
+        voice_name = str(data.get('voice', config.get('gemini_tts_voice', 'Kore'))).strip() or 'Kore'
+        language_code = str(data.get('language_code', config.get('gemini_tts_language_code', 'de-DE'))).strip() or 'de-DE'
+        audio_encoding = str(data.get('audio_encoding', config.get('gemini_tts_audio_encoding', 'MP3'))).strip().upper() or 'MP3'
+
+        payload = {
+            'input': {
+                'text': text
+            },
+            'voice': {
+                'languageCode': language_code,
+                'name': voice_name,
+                'modelName': model_name
+            },
+            'audioConfig': {
+                'audioEncoding': audio_encoding
+            }
+        }
+
+        if prompt:
+            payload['input']['prompt'] = prompt
+
+        endpoint = f"https://texttospeech.googleapis.com/v1/text:synthesize?key={api_key}"
+        upstream = requests.post(endpoint, json=payload, timeout=60)
+
+        try:
+            upstream_data = upstream.json()
+        except Exception:
+            upstream_data = {'error': {'message': upstream.text[:500]}}
+
+        if upstream.status_code >= 400:
+            upstream_error = upstream_data.get('error', {}) if isinstance(upstream_data, dict) else {}
+            error_message = upstream_error.get('message') or f"Google TTS Fehler ({upstream.status_code})"
+            return jsonify({'success': False, 'error': error_message}), 502
+
+        audio_content = str(upstream_data.get('audioContent', '')).strip() if isinstance(upstream_data, dict) else ''
+        if not audio_content:
+            return jsonify({'success': False, 'error': 'Keine Audiodaten von Gemini TTS erhalten'}), 502
+
+        mime_type_map = {
+            'MP3': 'audio/mpeg',
+            'LINEAR16': 'audio/wav',
+            'ALAW': 'audio/basic',
+            'MULAW': 'audio/basic',
+            'OGG_OPUS': 'audio/ogg',
+            'PCM': 'audio/L16'
+        }
+
+        return jsonify({
+            'success': True,
+            'audio_base64': audio_content,
+            'mime_type': mime_type_map.get(audio_encoding, 'audio/mpeg'),
+            'model': model_name,
+            'voice': voice_name,
+            'language_code': language_code,
+            'audio_encoding': audio_encoding
+        })
+    except Exception as e:
+        return jsonify({'success': False, 'error': str(e)}), 500
 
 # Kalender API Endpunkte
 @app.route('/api/calendar/status', methods=['GET'])

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -17,7 +17,6 @@ const SIDEBAR_COLLAPSED_KEY = 'mynd_sidebar_collapsed_v1';
 const DISPLAY_NAME_STORAGE_KEY = 'mynd_display_name';
 const LOCATION_AUTO_RESOLVE_KEY = 'mynd_location_auto_resolve_v1';
 const BRIEFING_SEEN_KEY = 'mynd_seen_briefings_v1';
-const VOICE_SELECTION_STORAGE_KEY = 'mynd_voice_selection_v1';
 
 const SPEECH_LANG_MAP = {
   de: 'de-DE',
@@ -196,6 +195,7 @@ export default function HomePage() {
   const [voiceError, setVoiceError] = useState('');
   const [speechCapabilities, setSpeechCapabilities] = useState({ input: false, output: false });
   const [selectedVoiceUri, setSelectedVoiceUri] = useState('');
+  const [ttsProvider, setTtsProvider] = useState('browser');
   
   const [aiProtocol, setAiProtocol] = useState('http');
   const [aiHost, setAiHost] = useState('127.0.0.1');
@@ -286,6 +286,7 @@ export default function HomePage() {
   const progressIntervalRef = useRef(null);
   const requestAbortRef = useRef(null);
   const speechRecognitionRef = useRef(null);
+  const activeAudioRef = useRef(null);
   
   const messagesEndRef = useRef(null);
   const inputRef = useRef(null);
@@ -615,11 +616,6 @@ export default function HomePage() {
         setDisplayName(rawDisplayName);
       }
 
-      const storedVoiceSelection = localStorage.getItem(VOICE_SELECTION_STORAGE_KEY);
-      if (storedVoiceSelection) {
-        setSelectedVoiceUri(storedVoiceSelection);
-      }
-
       const rawChats = localStorage.getItem(CHAT_STORAGE_KEY);
       const rawActiveChatId = localStorage.getItem(ACTIVE_CHAT_STORAGE_KEY);
       const rawSidebarCollapsed = localStorage.getItem(SIDEBAR_COLLAPSED_KEY);
@@ -670,14 +666,6 @@ export default function HomePage() {
       console.error('Error saving sidebar state:', err);
     }
   }, [isSidebarCollapsed]);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(VOICE_SELECTION_STORAGE_KEY, selectedVoiceUri || '');
-    } catch (err) {
-      console.error('Error saving voice selection:', err);
-    }
-  }, [selectedVoiceUri]);
 
   useEffect(() => {
     if (!photoPreview.open) return undefined;
@@ -791,6 +779,8 @@ export default function HomePage() {
       setAiHost(url.hostname);
       setAiPort(url.port || '11434');
       setAiModel(config.model);
+      setTtsProvider(String(config.tts_provider || 'browser').toLowerCase() === 'gemini' ? 'gemini' : 'browser');
+      setSelectedVoiceUri(String(config.browser_tts_voice_uri || ''));
       setAiStatus('Loaded');
     } catch (err) {
       setAiStatus('Error loading config');
@@ -1215,48 +1205,123 @@ export default function HomePage() {
   };
 
   const speakAssistantText = (text) => {
-    if (!speechSynthesisSupported) return;
     const prepared = cleanTextForSpeech(text).slice(0, 1100);
     if (!prepared) return;
 
-    try {
-      window.speechSynthesis.cancel();
-      const utterance = new window.SpeechSynthesisUtterance(prepared);
-      const locale = resolveSpeechLocale(language);
-      utterance.lang = locale;
-      utterance.rate = 1;
-      utterance.pitch = 1;
-
-      const browserVoices = window.speechSynthesis.getVoices();
-      const selectedVoice = selectedVoiceUri
-        ? browserVoices.find((voice) => voice.voiceURI === selectedVoiceUri)
-        : null;
-      const matchingVoice = selectedVoice
-        || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(language.toLowerCase()))
-        || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(locale.slice(0, 2).toLowerCase()));
-
-      if (matchingVoice) {
-        utterance.voice = matchingVoice;
+    const stopAudioPlayback = () => {
+      const activeAudio = activeAudioRef.current;
+      if (activeAudio) {
+        try {
+          activeAudio.pause();
+        } catch (_) {
+          // ignore pause errors from stale audio instances
+        }
+        activeAudioRef.current = null;
       }
+    };
 
-      utterance.onstart = () => {
-        setIsSpeaking(true);
-      };
+    const speakWithBrowser = () => {
+      if (!speechSynthesisSupported) return;
 
-      utterance.onend = () => {
+      try {
+        stopAudioPlayback();
+        window.speechSynthesis.cancel();
+        const utterance = new window.SpeechSynthesisUtterance(prepared);
+        const locale = resolveSpeechLocale(language);
+        utterance.lang = locale;
+        utterance.rate = 1;
+        utterance.pitch = 1;
+
+        const browserVoices = window.speechSynthesis.getVoices();
+        const selectedVoice = selectedVoiceUri
+          ? browserVoices.find((voice) => voice.voiceURI === selectedVoiceUri)
+          : null;
+        const matchingVoice = selectedVoice
+          || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(language.toLowerCase()))
+          || browserVoices.find((voice) => voice.lang?.toLowerCase().startsWith(locale.slice(0, 2).toLowerCase()));
+
+        if (matchingVoice) {
+          utterance.voice = matchingVoice;
+        }
+
+        utterance.onstart = () => {
+          setIsSpeaking(true);
+        };
+
+        utterance.onend = () => {
+          setIsSpeaking(false);
+        };
+
+        utterance.onerror = () => {
+          setIsSpeaking(false);
+          setVoiceError(language === 'de' ? 'Sprachausgabe fehlgeschlagen.' : 'Text-to-speech failed.');
+        };
+
+        window.speechSynthesis.speak(utterance);
+      } catch (err) {
         setIsSpeaking(false);
-      };
+        setVoiceError(language === 'de' ? 'Sprachausgabe nicht verfuegbar.' : 'Text-to-speech is unavailable.');
+      }
+    };
 
-      utterance.onerror = () => {
-        setIsSpeaking(false);
-        setVoiceError(language === 'de' ? 'Sprachausgabe fehlgeschlagen.' : 'Text-to-speech failed.');
-      };
+    const speakWithGemini = async () => {
+      try {
+        stopAudioPlayback();
+        if (speechSynthesisSupported) {
+          window.speechSynthesis.cancel();
+        }
 
-      window.speechSynthesis.speak(utterance);
-    } catch (err) {
-      setIsSpeaking(false);
-      setVoiceError(language === 'de' ? 'Sprachausgabe nicht verfuegbar.' : 'Text-to-speech is unavailable.');
+        const response = await fetch(`${API_BASE}/api/tts/synthesize`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            text: prepared,
+            language_code: resolveSpeechLocale(language)
+          })
+        });
+        const data = await safeReadJson(response);
+
+        if (!response.ok || data?.success === false || !data?.audio_base64) {
+          throw new Error(data?.error || `Gemini TTS request failed (${response.status})`);
+        }
+
+        const mimeType = data?.mime_type || 'audio/mpeg';
+        const audio = new Audio(`data:${mimeType};base64,${data.audio_base64}`);
+        activeAudioRef.current = audio;
+
+        audio.onplay = () => {
+          setIsSpeaking(true);
+          setVoiceError('');
+        };
+        audio.onended = () => {
+          setIsSpeaking(false);
+          if (activeAudioRef.current === audio) {
+            activeAudioRef.current = null;
+          }
+        };
+        audio.onerror = () => {
+          setIsSpeaking(false);
+          if (activeAudioRef.current === audio) {
+            activeAudioRef.current = null;
+          }
+          setVoiceError(language === 'de' ? 'Gemini-Audio konnte nicht abgespielt werden.' : 'Gemini audio playback failed.');
+        };
+
+        await audio.play();
+      } catch (err) {
+        setVoiceError(language === 'de'
+          ? `Gemini-TTS Fehler: ${err.message}. Fallback auf Browser-Stimme.`
+          : `Gemini TTS error: ${err.message}. Falling back to browser voice.`);
+        speakWithBrowser();
+      }
+    };
+
+    if (ttsProvider === 'gemini') {
+      speakWithGemini();
+      return;
     }
+
+    speakWithBrowser();
   };
 
   const startVoiceInput = () => {
@@ -1333,11 +1398,19 @@ export default function HomePage() {
         speechRecognitionRef.current.stop();
         speechRecognitionRef.current = null;
       }
+      if (activeAudioRef.current) {
+        try {
+          activeAudioRef.current.pause();
+        } catch (_) {
+          // ignore pause errors from stale audio instances
+        }
+        activeAudioRef.current = null;
+      }
       if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
         window.speechSynthesis.cancel();
       }
     };
-  }, []);
+  }, [speechSynthesisSupported]);
 
   const parseBackendDateTimeToInput = (value) => {
     if (!value || typeof value !== 'string') return '';

--- a/frontend/app/settings/page.js
+++ b/frontend/app/settings/page.js
@@ -9,7 +9,6 @@ import { ThemeSelector } from '../../components/ThemeSelector';
 const API_BASE = '';
 const SIDEBAR_COLLAPSED_KEY = 'mynd_sidebar_collapsed_v1';
 const DISPLAY_NAME_STORAGE_KEY = 'mynd_display_name';
-const VOICE_SELECTION_STORAGE_KEY = 'mynd_voice_selection_v1';
 const API_DISPLAY_NAMES = {
   immich: 'Immich',
   homeassistant: 'Home Assistant',
@@ -184,6 +183,14 @@ export default function SettingsPage() {
   const [speechSynthesisSupported, setSpeechSynthesisSupported] = useState(false);
   const [availableVoices, setAvailableVoices] = useState([]);
   const [selectedVoiceUri, setSelectedVoiceUri] = useState('');
+  const [ttsProvider, setTtsProvider] = useState('browser');
+  const [geminiTtsModel, setGeminiTtsModel] = useState('gemini-2.5-flash-tts');
+  const [geminiTtsVoice, setGeminiTtsVoice] = useState('Kore');
+  const [geminiTtsLanguageCode, setGeminiTtsLanguageCode] = useState('de-DE');
+  const [geminiTtsStylePrompt, setGeminiTtsStylePrompt] = useState('');
+  const [geminiTtsAudioEncoding, setGeminiTtsAudioEncoding] = useState('MP3');
+  const [geminiTtsApiKey, setGeminiTtsApiKey] = useState('');
+  const [geminiTtsApiKeySet, setGeminiTtsApiKeySet] = useState(false);
   
   const [aiProtocol, setAiProtocol] = useState('http');
   const [aiHost, setAiHost] = useState('127.0.0.1');
@@ -285,6 +292,11 @@ export default function SettingsPage() {
   const visibleVoices = language === 'de'
     ? availableVoices.filter((voice) => String(voice.lang || '').toLowerCase().startsWith('de'))
     : availableVoices;
+  const geminiVoices = [
+    'Achernar', 'Achird', 'Algenib', 'Algieba', 'Alnilam', 'Aoede', 'Autonoe', 'Callirrhoe', 'Charon', 'Despina',
+    'Enceladus', 'Erinome', 'Fenrir', 'Gacrux', 'Iapetus', 'Kore', 'Laomedeia', 'Leda', 'Orus', 'Pulcherrima',
+    'Puck', 'Rasalgethi', 'Sadachbia', 'Sadaltager', 'Schedar', 'Sulafat', 'Umbriel', 'Vindemiatrix', 'Zephyr', 'Zubenelgenubi'
+  ];
 
   useEffect(() => {
     loadAIConfig();
@@ -342,15 +354,6 @@ export default function SettingsPage() {
     const supportsSynthesis = 'speechSynthesis' in window && typeof window.SpeechSynthesisUtterance !== 'undefined';
     setSpeechSynthesisSupported(supportsSynthesis);
 
-    try {
-      const storedVoice = localStorage.getItem(VOICE_SELECTION_STORAGE_KEY);
-      if (storedVoice) {
-        setSelectedVoiceUri(storedVoice);
-      }
-    } catch (err) {
-      console.error('Error loading selected voice:', err);
-    }
-
     if (!supportsSynthesis) return;
 
     const updateVoices = () => {
@@ -370,14 +373,6 @@ export default function SettingsPage() {
       window.speechSynthesis.removeEventListener('voiceschanged', updateVoices);
     };
   }, []);
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(VOICE_SELECTION_STORAGE_KEY, selectedVoiceUri || '');
-    } catch (err) {
-      console.error('Error saving selected voice:', err);
-    }
-  }, [selectedVoiceUri]);
 
   useEffect(() => {
     if (!selectedVoiceUri) return;
@@ -601,6 +596,15 @@ export default function SettingsPage() {
       setAiHost(url.hostname);
       setAiPort(url.port || '11434');
       setAiModel(config.model);
+      setTtsProvider(String(config.tts_provider || 'browser').toLowerCase() === 'gemini' ? 'gemini' : 'browser');
+      setSelectedVoiceUri(String(config.browser_tts_voice_uri || ''));
+      setGeminiTtsModel(String(config.gemini_tts_model || 'gemini-2.5-flash-tts'));
+      setGeminiTtsVoice(String(config.gemini_tts_voice || 'Kore'));
+      setGeminiTtsLanguageCode(String(config.gemini_tts_language_code || 'de-DE'));
+      setGeminiTtsStylePrompt(String(config.gemini_tts_style_prompt || ''));
+      setGeminiTtsAudioEncoding(String(config.gemini_tts_audio_encoding || 'MP3'));
+      setGeminiTtsApiKeySet(Boolean(config.gemini_tts_api_key_set));
+      setGeminiTtsApiKey('');
       setAiStatus(tr('Geladen', 'Loaded'));
     } catch (err) {
       setAiStatus(tr('Fehler beim Laden der Konfiguration', 'Error loading config'));
@@ -712,16 +716,35 @@ export default function SettingsPage() {
   const saveAIConfig = async () => {
     try {
       const baseUrl = `${aiProtocol}://${aiHost}:${aiPort}`;
+      const payload = {
+        base_url: baseUrl,
+        model: aiModel,
+        tts_provider: ttsProvider,
+        browser_tts_voice_uri: selectedVoiceUri,
+        gemini_tts_model: geminiTtsModel,
+        gemini_tts_voice: geminiTtsVoice,
+        gemini_tts_language_code: geminiTtsLanguageCode,
+        gemini_tts_style_prompt: geminiTtsStylePrompt,
+        gemini_tts_audio_encoding: geminiTtsAudioEncoding
+      };
+
+      if (geminiTtsApiKey.trim()) {
+        payload.gemini_tts_api_key = geminiTtsApiKey.trim();
+      }
+
       const res = await fetch(`${API_BASE}/api/ai/config`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ base_url: baseUrl, model: aiModel })
+        body: JSON.stringify(payload)
       });
+      const data = await res.json();
       if (res.ok) {
         setAiStatus(tr('Erfolgreich gespeichert', 'Saved successfully'));
+        setGeminiTtsApiKey('');
+        setGeminiTtsApiKeySet(Boolean(data?.gemini_tts_api_key_set || geminiTtsApiKeySet || geminiTtsApiKey.trim()));
         updateStatus();
       } else {
-        setAiStatus(tr('Fehler beim Speichern', 'Error saving'));
+        setAiStatus(`Error: ${data?.error || tr('Fehler beim Speichern', 'Error saving')}`);
       }
     } catch (err) {
       setAiStatus('Error: ' + err.message);
@@ -1407,6 +1430,99 @@ export default function SettingsPage() {
                     <button className="btn primary" onClick={saveAIConfig}>{t('save')}</button>
                   </div>
                   {aiStatus && <div className="status-text">{aiStatus}</div>}
+                </div>
+
+                <div className="panel-section" style={{marginTop: '2rem'}}>
+                  <div className="section-title">Gemini TTS</div>
+                  <div className="input-group">
+                    <label>{tr('TTS-Anbieter', 'TTS Provider')}</label>
+                    <select value={ttsProvider} onChange={(e) => setTtsProvider(e.target.value)}>
+                      <option value="browser">{tr('Browser (lokal)', 'Browser (local)')}</option>
+                      <option value="gemini">Gemini TTS</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Browser-Stimme', 'Browser Voice')}</label>
+                    {speechSynthesisSupported ? (
+                      <>
+                        <select value={selectedVoiceUri} onChange={(e) => setSelectedVoiceUri(e.target.value)}>
+                          <option value="">{tr('Automatische Stimme', 'Automatic voice')}</option>
+                          {visibleVoices.map((voice) => (
+                            <option key={voice.voiceURI} value={voice.voiceURI}>
+                              {formatVoiceLabel(voice)}
+                            </option>
+                          ))}
+                        </select>
+                        {language === 'de' && (
+                          <div className="status-text">{tr('Bei deutscher Sprache werden nur deutsche Stimmen angeboten.', 'Only German voices are shown for German language.')}</div>
+                        )}
+                      </>
+                    ) : (
+                      <div className="status-text">{tr('Sprachausgabe wird von diesem Browser nicht unterstuetzt.', 'Speech synthesis is not supported in this browser.')}</div>
+                    )}
+                  </div>
+
+                  <div className="input-group">
+                    <label>Gemini API Key</label>
+                    <input
+                      type="password"
+                      value={geminiTtsApiKey}
+                      onChange={(e) => setGeminiTtsApiKey(e.target.value)}
+                      placeholder={geminiTtsApiKeySet ? tr('Bereits gesetzt (neu eingeben zum Ueberschreiben)', 'Already set (enter new key to overwrite)') : 'AIza...'}
+                    />
+                    {geminiTtsApiKeySet && !geminiTtsApiKey.trim() && (
+                      <div className="status-text">{tr('API Key ist gesetzt.', 'API key is set.')}</div>
+                    )}
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Modell', 'Gemini Model')}</label>
+                    <select value={geminiTtsModel} onChange={(e) => setGeminiTtsModel(e.target.value)}>
+                      <option value="gemini-2.5-flash-tts">gemini-2.5-flash-tts</option>
+                      <option value="gemini-2.5-pro-tts">gemini-2.5-pro-tts</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Stimme', 'Gemini Voice')}</label>
+                    <select value={geminiTtsVoice} onChange={(e) => setGeminiTtsVoice(e.target.value)}>
+                      {geminiVoices.map((voiceName) => (
+                        <option key={voiceName} value={voiceName}>{voiceName}</option>
+                      ))}
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Gemini Sprache (BCP-47)', 'Gemini Language (BCP-47)')}</label>
+                    <input type="text" value={geminiTtsLanguageCode} onChange={(e) => setGeminiTtsLanguageCode(e.target.value)} placeholder="de-DE" />
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Audio-Format', 'Audio Encoding')}</label>
+                    <select value={geminiTtsAudioEncoding} onChange={(e) => setGeminiTtsAudioEncoding(e.target.value)}>
+                      <option value="MP3">MP3</option>
+                      <option value="LINEAR16">LINEAR16</option>
+                      <option value="OGG_OPUS">OGG_OPUS</option>
+                      <option value="MULAW">MULAW</option>
+                      <option value="ALAW">ALAW</option>
+                      <option value="PCM">PCM</option>
+                    </select>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Stil-Prompt (optional)', 'Style Prompt (optional)')}</label>
+                    <input
+                      type="text"
+                      value={geminiTtsStylePrompt}
+                      onChange={(e) => setGeminiTtsStylePrompt(e.target.value)}
+                      placeholder={tr('z.B. Sprich ruhig und freundlich', 'e.g. Speak in a calm and friendly tone')}
+                    />
+                  </div>
+
+                  <div className="button-group">
+                    <button className="btn primary" onClick={saveAIConfig}>{t('save')}</button>
+                  </div>
                 </div>
 
                 <div className="panel-section" style={{marginTop: '2rem'}}>
@@ -2297,29 +2413,6 @@ export default function SettingsPage() {
                       <option key={entry.code} value={entry.code}>{entry.label}</option>
                     ))}
                   </select>
-                </div>
-                <div className="input-group" style={{ marginBottom: '1rem' }}>
-                  <label>{tr('Stimme', 'Voice')}</label>
-                  {speechSynthesisSupported ? (
-                    <>
-                      <select value={selectedVoiceUri} onChange={(e) => setSelectedVoiceUri(e.target.value)}>
-                        <option value="">{tr('Automatische Stimme', 'Automatic voice')}</option>
-                        {visibleVoices.map((voice) => (
-                          <option key={voice.voiceURI} value={voice.voiceURI}>
-                            {formatVoiceLabel(voice)}
-                          </option>
-                        ))}
-                      </select>
-                      {language === 'de' && (
-                        <div className="status-text">{tr('Bei deutscher Sprache werden nur deutsche Stimmen angeboten.', 'Only German voices are shown for German language.')}</div>
-                      )}
-                      {language === 'de' && visibleVoices.length === 0 && (
-                        <div className="status-text">{tr('Keine deutschen Stimmen im Browser gefunden. Bitte installiere eine deutsche Systemstimme.', 'No German voices found in the browser. Please install a German system voice.')}</div>
-                      )}
-                    </>
-                  ) : (
-                    <div className="status-text">{tr('Sprachausgabe wird von diesem Browser nicht unterstuetzt.', 'Speech synthesis is not supported in this browser.')}</div>
-                  )}
                 </div>
                 <ThemeSelector
                   currentTheme={theme}


### PR DESCRIPTION
## Zusammenfassung
- Gemini-TTS als neuer TTS-Provider integriert
- Gemini-TTS-Einstellungen im Settings-Tab (Config) hinzugefuegt
- API Key, Modell, Stimme, Sprache, Audio-Format und Stil-Prompt konfigurierbar gemacht
- Browser-Stimme weiterhin als Fallback/Alternative unterstuetzt

## Backend
- `/api/ai/config` um TTS-Felder erweitert
- Neuer Endpoint `/api/tts/synthesize` fuer Gemini-TTS hinzugefuegt
- Input-Limits fuer Prompt/Text gemaess Gemini-TTS-Dokumentation abgesichert
- Gemini-Fehlerbehandlung mit klaren Fehlermeldungen

## Frontend
- Chat-Voice-Playback nutzt nun konfigurierbaren TTS-Provider (`browser` oder `gemini`)
- Bei Gemini-Fehlern erfolgt Fallback auf Browser-TTS
- Voice-Konfiguration zentral in den Einstellungen, nicht im Eingabefeld
- Bei deutscher UI-Sprache werden nur deutsche Browser-Stimmen angezeigt
