### PR TITLE
Reuse saved email accounts for email indexing

### DIFF
--- a/Frontend/app/settings/page.js
+++ b/Frontend/app/settings/page.js
@@ -253,11 +253,46 @@ export default function SettingsPage() {
   const [nextcloudDisplayName, setNextcloudDisplayName] = useState('');
   const [nextcloudLoggingIn, setNextcloudLoggingIn] = useState(false);
 
+  // Email Indexing State
+  const [emailConfig, setEmailConfig] = useState({
+    imap_host: '',
+    imap_port: 993,
+    username: '',
+    password: '',
+    folders: 'INBOX',
+    max_emails: 50,
+    use_ssl: true
+  });
+  const [emailConfigStatus, setEmailConfigStatus] = useState('');
+  const [emailTestLoading, setEmailTestLoading] = useState(false);
+  const [emailIndexingMode, setEmailIndexingMode] = useState('manual');
+  const [emailIndexingAccountId, setEmailIndexingAccountId] = useState('');
+  const [emailIndexingStatus, setEmailIndexingStatus] = useState('idle');
+  const [emailIndexingProgress, setEmailIndexingProgress] = useState(0);
+  const [emailIndexingDetails, setEmailIndexingDetails] = useState({
+    processed: 0,
+    elapsed: 0,
+    current_folder: '',
+    message: ''
+  });
+
   useEffect(() => {
     if (typeof window !== 'undefined' && !briefingTalkWebhookUrl.trim()) {
       setBriefingTalkWebhookUrl(`${window.location.origin}/api/nextcloud/talk/webhook`);
     }
   }, [briefingTalkWebhookUrl]);
+
+  useEffect(() => {
+    if (briefingEmailAccounts.length > 0) {
+      setEmailIndexingMode((current) => current === 'manual' && !emailIndexingAccountId ? 'existing' : current);
+      if (!emailIndexingAccountId || !briefingEmailAccounts.some((account) => account.account_id === emailIndexingAccountId)) {
+        setEmailIndexingAccountId(briefingEmailAccounts[0].account_id);
+      }
+    } else if (emailIndexingMode === 'existing') {
+      setEmailIndexingMode('manual');
+      setEmailIndexingAccountId('');
+    }
+  }, [briefingEmailAccounts, emailIndexingAccountId, emailIndexingMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -372,6 +407,7 @@ export default function SettingsPage() {
     loadCalendarConfig();
     loadCalendarOptions();
     loadIndexingConfig();
+    loadEmailIndexingConfig();
     loadAllApis();
     updateStatus();
     // initial load of persistent indexing stats
@@ -929,6 +965,54 @@ export default function SettingsPage() {
     }
   };
 
+  const loadEmailIndexingConfig = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/config`);
+      if (res.ok) {
+        const config = await res.json();
+        // Don't display the password for security
+        setEmailConfig(prev => ({
+          ...prev,
+          imap_host: config.imap_host || '',
+          imap_port: config.imap_port || 993,
+          username: config.username || '',
+          folders: config.folders || 'INBOX',
+          max_emails: config.max_emails || 50,
+          use_ssl: config.use_ssl !== false
+          // password stays as-is (empty after load for security)
+        }));
+      }
+    } catch (err) {
+      console.error('Error loading email indexing config:', err);
+    }
+  };
+
+  const buildEmailIndexingPayload = () => {
+    const safeFolders = String(emailConfig.folders || 'INBOX').trim() || 'INBOX';
+    const safeMaxEmails = Number.isFinite(Number(emailConfig.max_emails)) ? Number(emailConfig.max_emails) : 50;
+
+    if (emailIndexingMode === 'existing' && emailIndexingAccountId) {
+      return {
+        account_id: emailIndexingAccountId,
+        folders: safeFolders,
+        max_emails: safeMaxEmails,
+        use_ssl: Boolean(emailConfig.use_ssl)
+      };
+    }
+
+    return {
+      email_config: {
+        imap_host: String(emailConfig.imap_host || '').trim(),
+        imap_port: Number.isFinite(Number(emailConfig.imap_port)) ? Number(emailConfig.imap_port) : 993,
+        username: String(emailConfig.username || '').trim(),
+        password: String(emailConfig.password || ''),
+        folders: safeFolders,
+        max_emails: safeMaxEmails,
+        use_ssl: Boolean(emailConfig.use_ssl)
+      }
+    };
+  };
+
   const saveIndexingConfig = async () => {
     try {
       const res = await fetch(`${API_BASE}/api/indexing/path`, {
@@ -1070,6 +1154,113 @@ export default function SettingsPage() {
       }
     } catch (err) {
       setIndexingStatus('error: ' + err.message);
+    }
+  };
+
+  // ========== Email Indexing Functions ==========
+  
+  const testEmailConnection = async () => {
+    setEmailTestLoading(true);
+    try {
+      const payload = emailIndexingMode === 'existing' && emailIndexingAccountId
+        ? { account_id: emailIndexingAccountId }
+        : { config: buildEmailIndexingPayload().email_config };
+
+      const res = await fetch(`${API_BASE}/api/email/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setEmailConfigStatus(data?.message || tr('Verbindung erfolgreich.', 'Connection successful.'));
+      } else {
+        const data = await res.json();
+        setEmailConfigStatus(tr('Fehler: ', 'Error: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    } finally {
+      setEmailTestLoading(false);
+    }
+  };
+
+  const saveEmailConfig = async () => {
+    try {
+      if (emailIndexingMode === 'existing' && emailIndexingAccountId) {
+        setEmailConfigStatus(tr('Für bestehende Konten ist kein separates Speichern nötig.', 'No separate save is needed for existing accounts.'));
+        return;
+      }
+
+      const res = await fetch(`${API_BASE}/api/email-indexing/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(emailConfig)
+      });
+      if (res.ok) {
+        setEmailConfigStatus(tr('E-Mail-Konfiguration erfolgreich gespeichert!', 'Email configuration saved successfully!'));
+      } else {
+        const data = await res.json();
+        setEmailConfigStatus(tr('Fehler beim Speichern: ', 'Error saving: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    }
+  };
+
+  const startEmailIndexing = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildEmailIndexingPayload())
+      });
+      
+      if (res.ok) {
+        setEmailIndexingStatus('running');
+        const progressInterval = setInterval(async () => {
+          try {
+            const res = await fetch(`${API_BASE}/api/email-indexing/progress`);
+            if (res.ok) {
+              const data = await res.json();
+              setEmailIndexingProgress(Math.round(data.progress_percentage || 0));
+              setEmailIndexingDetails({
+                processed: data.emails_processed || 0,
+                elapsed: Math.round(data.elapsed_time || 0),
+                current_folder: data.current_folder || '',
+                message: data.status_message || ''
+              });
+              
+              if (data.status === 'completed' || data.status === 'error') {
+                setEmailIndexingStatus(data.status);
+                clearInterval(progressInterval);
+              }
+            }
+          } catch (err) {
+            console.error('Error checking email indexing progress:', err);
+          }
+        }, 1000);
+      } else {
+        const data = await res.json();
+        setEmailIndexingStatus('error');
+        setEmailConfigStatus(tr('Fehler: ', 'Error: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailIndexingStatus('error');
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    }
+  };
+
+  const stopEmailIndexing = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/stop`, {
+        method: 'POST'
+      });
+      if (res.ok) {
+        setEmailIndexingStatus('stopped');
+      }
+    } catch (err) {
+      console.error('Error stopping email indexing:', err);
     }
   };
 
@@ -2887,6 +3078,231 @@ export default function SettingsPage() {
                               <div key={index} style={{marginBottom: '0.25rem'}}>• {error}</div>
                             ))}
                           </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="panel-section" style={{marginTop: '2rem'}}>
+                  <div className="section-title">{tr('E-Mail-Indexierung', 'Email Indexing')}</div>
+                  <p style={{fontSize: '0.9rem', color: 'var(--muted)', margin: '0.5rem 0'}}>
+                    {tr('Indexiere deine E-Mails für die semantische Suche', 'Index your emails for semantic search')}
+                  </p>
+
+                  <div className="input-group">
+                    <label>{tr('Quelle für die E-Mail-Indexierung', 'Email indexing source')}</label>
+                    <select
+                      value={emailIndexingMode}
+                      onChange={(e) => setEmailIndexingMode(e.target.value)}
+                    >
+                      <option value="existing">{tr('Gespeichertes Konto verwenden', 'Use saved account')}</option>
+                      <option value="manual">{tr('Eigenes Konto manuell angeben', 'Enter custom account')}</option>
+                    </select>
+                  </div>
+
+                  {emailIndexingMode === 'existing' ? (
+                    <>
+                      <div className="input-group">
+                        <label>{tr('Gespeichertes E-Mail-Konto', 'Saved email account')}</label>
+                        <select
+                          value={emailIndexingAccountId}
+                          onChange={(e) => setEmailIndexingAccountId(e.target.value)}
+                        >
+                          {briefingEmailAccounts.length === 0 ? (
+                            <option value="">{tr('Keine Konten verfügbar', 'No accounts available')}</option>
+                          ) : (
+                            briefingEmailAccounts.map((account) => (
+                              <option key={account.account_id} value={account.account_id}>
+                                {account.display_name}
+                              </option>
+                            ))
+                          )}
+                        </select>
+                        <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                          {tr('Es wird die unter APIs bereits gespeicherte Konfiguration verwendet. Manuelle IMAP-Daten sind dann nicht nötig.', 'The already saved API configuration is used. Manual IMAP details are not needed.')} 
+                        </small>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="input-group">
+                        <label>IMAP Host</label>
+                        <input 
+                          type="text" 
+                          value={emailConfig.imap_host}
+                          onChange={(e) => setEmailConfig({...emailConfig, imap_host: e.target.value})}
+                          placeholder="imap.gmail.com"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>IMAP Port</label>
+                        <input 
+                          type="number" 
+                          value={emailConfig.imap_port}
+                          onChange={(e) => setEmailConfig({...emailConfig, imap_port: parseInt(e.target.value)})}
+                          placeholder="993"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>{tr('E-Mail-Adresse', 'Email Address')}</label>
+                        <input 
+                          type="email" 
+                          value={emailConfig.username}
+                          onChange={(e) => setEmailConfig({...emailConfig, username: e.target.value})}
+                          placeholder="your-email@example.com"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>{tr('Passwort', 'Password')}</label>
+                        <input 
+                          type="password" 
+                          value={emailConfig.password}
+                          onChange={(e) => setEmailConfig({...emailConfig, password: e.target.value})}
+                          placeholder="••••••••"
+                        />
+                        <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                          {tr('Für Gmail: Verwende App-Passwort (nicht dein normales Passwort)', 'For Gmail: Use App Password (not your regular password)')}
+                        </small>
+                      </div>
+                    </>
+                  )}
+
+                  <div className="input-group">
+                    <label>{tr('Ordner (kommasepariert)', 'Folders (comma-separated)')}</label>
+                    <input 
+                      type="text" 
+                      value={emailConfig.folders}
+                      onChange={(e) => setEmailConfig({...emailConfig, folders: e.target.value})}
+                      placeholder="INBOX, Sent, Drafts"
+                    />
+                    <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                      {tr('Welche E-Mail-Ordner sollen indexiert werden?', 'Which email folders should be indexed?')}
+                    </small>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Max E-Mails pro Ordner', 'Max Emails per Folder')}</label>
+                    <input 
+                      type="number" 
+                      value={emailConfig.max_emails}
+                      onChange={(e) => setEmailConfig({...emailConfig, max_emails: parseInt(e.target.value)})}
+                      placeholder="50"
+                    />
+                  </div>
+
+                  <div className="input-group" style={{display: 'flex', alignItems: 'center'}}>
+                    <label style={{display: 'flex', alignItems: 'center', cursor: 'pointer', marginBottom: 0}}>
+                      <input 
+                        type="checkbox" 
+                        checked={emailConfig.use_ssl}
+                        onChange={(e) => setEmailConfig({...emailConfig, use_ssl: e.target.checked})}
+                        style={{marginRight: '0.5rem'}}
+                      />
+                      {tr('SSL/TLS verwenden', 'Use SSL/TLS')}
+                    </label>
+                  </div>
+
+                  <div className="button-group" style={{marginTop: '1.5rem'}}>
+                    <button className="btn secondary" onClick={testEmailConnection} disabled={emailTestLoading}>
+                      <i className="fas fa-flask" style={{marginRight: '0.5rem'}}></i>
+                      {emailTestLoading ? tr('Teste Verbindung...', 'Testing Connection...') : tr('Verbindung testen', 'Test Connection')}
+                    </button>
+                    {emailIndexingMode === 'manual' && (
+                      <button className="btn primary" onClick={saveEmailConfig} disabled={!emailConfig.imap_host || !emailConfig.username || !emailConfig.password}>
+                        <i className="fas fa-save" style={{marginRight: '0.5rem'}}></i>
+                        {tr('Manuelle Konfiguration speichern', 'Save manual config')}
+                      </button>
+                    )}
+                  </div>
+
+                  {emailConfigStatus && <div className={`status-text ${emailConfigStatus.includes('Fehler') ? 'error' : 'success'}`}>{emailConfigStatus}</div>}
+
+                  <div className="button-group" style={{marginTop: '1.5rem'}}>
+                    <button className="btn primary" onClick={startEmailIndexing} disabled={emailIndexingStatus === 'running'}>
+                      <i className="fas fa-envelope" style={{marginRight: '0.5rem'}}></i>
+                      {emailIndexingStatus === 'running' ? tr('E-Mail-Indexierung läuft...', 'Email Indexing...') : tr('E-Mail-Indexierung starten', 'Start Email Indexing')}
+                    </button>
+                    {emailIndexingStatus === 'running' && (
+                      <button className="btn secondary" onClick={stopEmailIndexing}>
+                        {tr('Stoppen', 'Stop')}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Email Indexing Progress */}
+                  {(emailIndexingStatus !== 'idle' || emailIndexingDetails.processed > 0) && (
+                    <div style={{marginTop: '1.5rem', padding: '1rem', background: 'var(--surface)', borderRadius: '8px', border: '1px solid var(--border)'}}>
+                      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem'}}>
+                        <h4 style={{margin: 0, fontSize: '1rem', fontWeight: '600'}}>
+                          <i className="fas fa-chart-line" style={{marginRight: '0.5rem'}}></i>
+                          {tr('E-Mail-Indexierungsfortschritt', 'Email Indexing Progress')}
+                        </h4>
+                        <span style={{
+                          fontSize: '0.8rem',
+                          padding: '0.25rem 0.75rem',
+                          borderRadius: '12px',
+                          background: emailIndexingStatus === 'running' ? 'var(--primary)' : 
+                                     emailIndexingStatus === 'completed' ? 'var(--success)' : 
+                                     emailIndexingStatus === 'error' ? 'var(--error)' : 'var(--muted)',
+                          color: 'white',
+                          fontWeight: '500'
+                        }}>
+                          {emailIndexingStatus.toUpperCase()}
+                        </span>
+                      </div>
+
+                      {emailIndexingStatus === 'running' && (
+                        <div className="progress-bar-wrapper" style={{marginBottom: '1rem'}}>
+                          <div className="progress-bar" style={{
+                            height: '8px',
+                            background: 'var(--border)',
+                            borderRadius: '4px',
+                            overflow: 'hidden',
+                            position: 'relative'
+                          }}>
+                            <div className="progress-fill" style={{
+                              height: '100%',
+                              background: 'linear-gradient(90deg, var(--primary), var(--primary-light))',
+                              transition: 'width 0.5s ease',
+                              width: `${emailIndexingProgress}%`,
+                              borderRadius: '4px'
+                            }}></div>
+                          </div>
+                          <div style={{display: 'flex', justifyContent: 'space-between', fontSize: '0.8rem', color: 'var(--muted)', marginTop: '0.5rem'}}>
+                            <span>{emailIndexingProgress}% {tr('abgeschlossen', 'Complete')}</span>
+                            <span>{emailIndexingDetails.processed} {tr('E-Mails verarbeitet', 'Emails Processed')}</span>
+                          </div>
+                        </div>
+                      )}
+
+                      <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '1rem'}}>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--primary)'}}>
+                            {emailIndexingDetails.processed}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('E-Mails verarbeitet', 'Emails Processed')}</div>
+                        </div>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--accent)'}}>
+                            {Math.floor((emailIndexingDetails.elapsed || 0) / 60)}:{((emailIndexingDetails.elapsed || 0) % 60).toString().padStart(2, '0')}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('Verstrichene Zeit', 'Time Elapsed')}</div>
+                        </div>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--success)'}}>
+                            {emailIndexingDetails.current_folder || '--'}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('Aktueller Ordner', 'Current Folder')}</div>
+                        </div>
+                      </div>
+
+                      {emailIndexingDetails.message && (
+                        <div style={{marginBottom: '1rem', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px', fontSize: '0.85rem', color: 'var(--muted)'}}>
+                          {emailIndexingDetails.message}
                         </div>
                       )}
                     </div>

--- a/backend/core/app.py
+++ b/backend/core/app.py
@@ -39,6 +39,7 @@ from backend.features.integration.homeassistant_client import HomeAssistantClien
 from backend.features.integration.uptimekuma_client import UptimeKumaClient
 from backend.features.integration.email_client import EmailClient
 from backend.features.knowledge.indexing import indexing_manager, IndexingProgress
+from backend.features.knowledge.email_indexing import email_indexing_manager, EmailIndexingProgress
 # from backend.features.knowledge.engine import SemanticSearchEngine
 # Temporär deaktiviert wegen faiss Problemen
 class SemanticSearchEngine:
@@ -3207,6 +3208,153 @@ def indexing_path_config():
         except Exception as e:
             return jsonify({'error': str(e)}), 500
 
+# ==================== EMAIL INDEXING ENDPOINTS ====================
+
+@app.route('/api/email-indexing/start', methods=['POST'])
+def start_email_indexing():
+    """Startet die E-Mail-Indexierung im Hintergrund"""
+    data = request.get_json(silent=True) or {}
+    account_id = str(data.get('account_id') or '').strip()
+    email_config = data.get('email_config') or data.get('config')
+    
+    # Wenn ein bestehendes Konto gewählt wurde, lade die vollständige gespeicherte Konfiguration serverseitig.
+    if account_id:
+        registry = get_api_registry()
+        saved_email_config = registry.load_config('email') or {}
+        accounts = saved_email_config.get('accounts') if isinstance(saved_email_config, dict) else []
+        if not isinstance(accounts, list) or not accounts:
+            return jsonify({'error': 'Keine gespeicherten E-Mail-Konten gefunden'}), 400
+
+        if not any(str(account.get('account_id') or account.get('id') or '').strip() == account_id for account in accounts if isinstance(account, dict)):
+            return jsonify({'error': 'Ausgewähltes E-Mail-Konto wurde nicht gefunden'}), 400
+
+        email_config = dict(saved_email_config)
+        email_config['selected_account_id'] = account_id
+        email_config['active_account_id'] = account_id
+
+        # Optionale Indexierungs-Overrides aus dem Request übernehmen.
+        for key in ('folders', 'max_emails', 'use_ssl'):
+            if key in data and data[key] not in (None, ''):
+                email_config[key] = data[key]
+
+    # Wenn keine explizite Auswahl übergeben wurde, die gespeicherte Indexierungs-Konfiguration verwenden.
+    if not email_config:
+        saved_config = email_indexing_manager.get_config(mask_password=False)
+        if not saved_config.get('password') and not saved_config.get('accounts'):
+            return jsonify({'error': 'Keine E-Mail-Konfiguration vorhanden'}), 400
+        email_config = saved_config
+    
+    try:
+        success = email_indexing_manager.start_indexing(email_config)
+        
+        if success:
+            return jsonify({
+                'status': 'started',
+                'message': 'E-Mail-Indexierung wurde gestartet'
+            })
+        else:
+            return jsonify({
+                'error': 'E-Mail-Indexierung läuft bereits oder Konfiguration fehlt'
+            }), 400
+            
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/email-indexing/stop', methods=['POST'])
+def stop_email_indexing():
+    """Stoppt die aktuelle E-Mail-Indexierung"""
+    try:
+        email_indexing_manager.stop_indexing()
+        return jsonify({
+            'status': 'stopped',
+            'message': 'E-Mail-Indexierung wurde gestoppt'
+        })
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/email-indexing/progress', methods=['GET'])
+def get_email_indexing_progress():
+    """Gibt den aktuellen E-Mail-Indexierungs-Fortschritt zurück"""
+    try:
+        progress = email_indexing_manager.get_progress()
+        return jsonify(progress)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/email-indexing/config', methods=['GET', 'POST'])
+def email_indexing_config():
+    """Lädt oder speichert die E-Mail-Indexierung-Konfiguration"""
+    if request.method == 'GET':
+        try:
+            config = email_indexing_manager.get_config(mask_password=True)
+            return jsonify(config)
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+    
+    elif request.method == 'POST':
+        try:
+            data = request.json
+            imap_host = data.get('imap_host')
+            username = data.get('username')
+            password = data.get('password')
+            imap_port = data.get('imap_port', 993)
+            folders = data.get('folders', 'INBOX')
+            max_emails = data.get('max_emails', 50)
+            use_ssl = data.get('use_ssl', True)
+            
+            if not all([imap_host, username, password]):
+                return jsonify({'error': 'IMAP Host, Username und Password werden benötigt'}), 400
+            
+            email_indexing_manager.save_email_config(
+                imap_host, username, password, imap_port, folders, max_emails, use_ssl
+            )
+            
+            return jsonify({
+                'status': 'saved',
+                'message': 'E-Mail-Konfiguration wurde gespeichert'
+            })
+            
+        except Exception as e:
+            return jsonify({'error': str(e)}), 500
+
+@app.route('/api/email-indexing/stats', methods=['GET'])
+def get_email_indexing_stats():
+    """Gibt E-Mail-Indexierungs-Statistiken zurück"""
+    try:
+        result = {}
+        
+        # Get current progress
+        try:
+            result['progress'] = email_indexing_manager.get_progress()
+        except Exception:
+            result['progress'] = {}
+        
+        # Get database stats if available
+        if knowledge_base and knowledge_base.db:
+            try:
+                # Get email-specific stats from database
+                conn = knowledge_base.db.connection
+                cursor = conn.cursor()
+                
+                cursor.execute("SELECT COUNT(*) as count FROM documents WHERE file_type = 'email'")
+                email_docs = cursor.fetchone()['count']
+                
+                cursor.execute("SELECT SUM(LENGTH(content)) as total_size FROM chunks WHERE document_id IN (SELECT id FROM documents WHERE file_type = 'email')")
+                total_size = cursor.fetchone()['total_size'] or 0
+                
+                result['db_stats'] = {
+                    'email_documents': email_docs,
+                    'total_email_content_size': total_size
+                }
+            except Exception as e:
+                result['db_stats_error'] = str(e)
+        
+        return jsonify(result)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+
+
 @app.route('/api/nextcloud/oauth/authorize', methods=['POST'])
 def nextcloud_oauth_authorize():
     """
@@ -5622,10 +5770,11 @@ def test_api_connection(api_name):
 def email_test_connection():
     """Test the IMAP email connection."""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True) or {}
         username = data.get('username')
         account_id = data.get('account_id')
-        client = get_email_client(username=username, account_id=account_id)
+        config = data.get('config')
+        client = get_email_client(username=username, account_id=account_id, config=config)
         if not client:
             return jsonify({'success': False, 'error': 'E-Mail nicht konfiguriert. Bitte IMAP-Einstellungen setzen.'}), 400
         success = client.test_connection()

--- a/backend/features/knowledge/email_indexing.py
+++ b/backend/features/knowledge/email_indexing.py
@@ -1,0 +1,451 @@
+import threading
+import time
+import sys
+import logging
+from typing import Dict, Optional, Callable, List
+from dataclasses import dataclass
+from enum import Enum
+import json
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..')))
+from backend.features.integration.email_client import EmailClient
+
+
+class EmailIndexingStatus(Enum):
+    IDLE = "idle"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    ERROR = "error"
+
+
+@dataclass
+class EmailIndexingProgress:
+    status: EmailIndexingStatus
+    current_folder: str = ""
+    current_email: str = ""
+    processed_emails: int = 0
+    total_emails: int = 0
+    errors: list = None
+    start_time: float = 0
+    end_time: float = 0
+    error_message: str = ""
+    
+    def __post_init__(self):
+        if self.errors is None:
+            self.errors = []
+    
+    @property
+    def progress_percentage(self) -> float:
+        if self.total_emails == 0:
+            return 0.0
+        return (self.processed_emails / self.total_emails) * 100
+    
+    @property
+    def elapsed_time(self) -> float:
+        if self.end_time > 0:
+            return self.end_time - self.start_time
+        elif self.start_time > 0:
+            return time.time() - self.start_time
+        return 0.0
+
+
+class EmailIndexingManager:
+    """Manager für Hintergrund-Indexierung von E-Mails"""
+    
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self.current_progress = EmailIndexingProgress(status=EmailIndexingStatus.IDLE)
+        self.indexing_thread: Optional[threading.Thread] = None
+        self.stop_event = threading.Event()
+        self.progress_callbacks: list = []
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
+        self.config_file = os.path.join(project_root, 'backend', 'config', 'email_indexing_config.json')
+        self.email_config: Dict = {}
+        self.max_workers = 4  # Reduziert für E-Mails (nicht so I/O intensiv)
+        self.batch_size = 20
+        self.last_indexing_start = 0
+        self.last_indexing_end = 0
+        self.chunk_size = 500  # Zeichen pro Chunk
+        
+    def add_progress_callback(self, callback: Callable[[EmailIndexingProgress], None]):
+        """Fügt einen Callback für Fortschritts-Updates hinzu"""
+        self.progress_callbacks.append(callback)
+    
+    def notify_progress(self):
+        """Benachrichtigt alle Callbacks über den aktuellen Fortschritt"""
+        for callback in self.progress_callbacks:
+            try:
+                callback(self.current_progress)
+            except Exception as e:
+                self.logger.error(f"Error in progress callback: {str(e)}")
+    
+    def save_email_config(self, imap_host: str, username: str, password: str, 
+                         imap_port: int = 993, folders: str = "INBOX", 
+                         max_emails: int = 50, use_ssl: bool = True):
+        """Speichert E-Mail-Konfiguration"""
+        self.email_config = {
+            'imap_host': imap_host,
+            'username': username,
+            'password': password,
+            'imap_port': imap_port,
+            'folders': folders,
+            'max_emails': max_emails,
+            'use_ssl': use_ssl
+        }
+        
+        try:
+            os.makedirs(os.path.dirname(self.config_file), exist_ok=True)
+            with open(self.config_file, 'w', encoding='utf-8') as f:
+                json.dump(self.email_config, f, indent=2)
+            self.logger.info("Email configuration saved")
+            return True
+        except Exception as e:
+            self.logger.error(f"Error saving email config: {str(e)}")
+            return False
+    
+    def load_email_config(self) -> bool:
+        """Lädt E-Mail-Konfiguration"""
+        try:
+            if os.path.exists(self.config_file):
+                with open(self.config_file, 'r', encoding='utf-8') as f:
+                    self.email_config = json.load(f)
+                self.logger.info("Email configuration loaded")
+                return bool(self.email_config.get('imap_host'))
+        except Exception as e:
+            self.logger.error(f"Error loading email config: {str(e)}")
+        return False
+    
+    def get_config(self, mask_password: bool = False) -> Dict:
+        """Gibt die aktuelle Konfiguration zurück"""
+        config = dict(self.email_config)
+        if mask_password and 'password' in config:
+            config['password'] = '***' if config['password'] else ''
+        return config
+    
+    def start_indexing(self, email_config: Optional[Dict] = None) -> bool:
+        """Startet die E-Mail-Indexierung im Hintergrund"""
+        if self.current_progress.status == EmailIndexingStatus.RUNNING:
+            self.logger.warning("Email indexing already running")
+            return False
+        
+        if email_config:
+            self.email_config = email_config
+            # Konfiguration speichern
+            try:
+                with open(self.config_file, 'w') as f:
+                    json.dump(self.email_config, f)
+                self.logger.info("Email configuration saved")
+            except Exception as e:
+                self.logger.error(f"Error saving config: {str(e)}")
+        elif not self.email_config:
+            self.logger.error("No email configuration available")
+            return False
+        
+        # Stop-Event zurücksetzen
+        self.stop_event.clear()
+        
+        # Neuen Fortschritt initialisieren
+        self.current_progress = EmailIndexingProgress(
+            status=EmailIndexingStatus.RUNNING,
+            start_time=time.time()
+        )
+        
+        # Track last indexing start time
+        self.last_indexing_start = time.time()
+        
+        # Indexierungsthread starten
+        self.indexing_thread = threading.Thread(
+            target=self._indexing_worker,
+            daemon=True
+        )
+        self.indexing_thread.start()
+        
+        self.logger.info("Email indexing started in background")
+        return True
+    
+    def stop_indexing(self):
+        """Stoppt die aktuelle E-Mail-Indexierung"""
+        self.stop_event.set()
+        if self.indexing_thread:
+            self.indexing_thread.join(timeout=5)
+        self.logger.info("Email indexing stopped")
+    
+    def get_progress(self) -> Dict:
+        """Gibt den aktuellen Fortschritt als Dict zurück"""
+        return {
+            'status': self.current_progress.status.value,
+            'current_folder': self.current_progress.current_folder,
+            'current_email': self.current_progress.current_email,
+            'processed_emails': self.current_progress.processed_emails,
+            'total_emails': self.current_progress.total_emails,
+            'progress_percentage': self.current_progress.progress_percentage,
+            'errors': self.current_progress.errors,
+            'elapsed_time': self.current_progress.elapsed_time,
+            'error_message': self.current_progress.error_message
+        }
+    
+    def _split_text(self, text: str, chunk_size: int = None) -> list:
+        """Teilt Text in kleinere Chunks"""
+        if chunk_size is None:
+            chunk_size = self.chunk_size
+        
+        if not text:
+            return []
+        
+        chunks = []
+        for i in range(0, len(text), chunk_size):
+            chunk = text[i:i + chunk_size].strip()
+            if chunk:  # Nur nicht-leere Chunks
+                chunks.append(chunk)
+        return chunks
+    
+    def _format_email_content(self, email_data: Dict) -> str:
+        """Formatiert E-Mail-Daten für die Indexierung"""
+        parts = []
+        
+        # Subject
+        subject = email_data.get('subject', '(Kein Betreff)')
+        parts.append(f"Betreff: {subject}")
+        
+        # From
+        sender = email_data.get('from', '')
+        if sender:
+            parts.append(f"Von: {sender}")
+        
+        # Date
+        date_str = email_data.get('date', '')
+        if date_str:
+            parts.append(f"Datum: {date_str}")
+        
+        # Body
+        body = email_data.get('body', '')
+        if body:
+            parts.append("")
+            parts.append("Inhalt:")
+            parts.append(body)
+        
+        return "\n".join(parts)
+    
+    def _indexing_worker(self):
+        """Hintergrund-Worker für die E-Mail-Indexierung"""
+        try:
+            # E-Mail-Client initialisieren
+            email_client = EmailClient(self.email_config)
+            
+            # Verbindung testen
+            try:
+                email_client.test_connection()
+            except Exception as e:
+                self.logger.warning(f"Email connection may have issues: {str(e)}")
+            
+            # Ordner abrufen
+            folders = self.email_config.get('folders', 'INBOX')
+            if folders.upper() in ('ALL', '*'):
+                try:
+                    folder_list = email_client.list_folder_tree()
+                    folders_to_process = [f.get('name') for f in folder_list]
+                except Exception:
+                    folders_to_process = ['INBOX']
+            else:
+                folders_to_process = [f.strip() for f in folders.split(',') if f.strip()]
+            
+            if not folders_to_process:
+                folders_to_process = ['INBOX']
+            
+            all_chunks = []
+            sources = []
+            total_emails_to_process = 0
+            
+            # Schritt 1: Zähle E-Mails
+            try:
+                for folder in folders_to_process:
+                    if self.stop_event.is_set():
+                        break
+                    self.current_progress.current_folder = folder
+                    self.notify_progress()
+                    
+                    try:
+                        # Anzahl der E-Mails in diesem Ordner
+                        email_list = email_client.search_emails(
+                            query='ALL',
+                            folder=folder,
+                            limit=self.email_config.get('max_emails', 50)
+                        )
+                        total_emails_to_process += len(email_list)
+                    except Exception as e:
+                        self.logger.warning(f"Error getting email count from {folder}: {str(e)}")
+                
+                self.current_progress.total_emails = total_emails_to_process
+                self.notify_progress()
+                
+                # Schritt 2: Verarbeite E-Mails
+                for folder in folders_to_process:
+                    if self.stop_event.is_set():
+                        break
+                    
+                    self.current_progress.current_folder = folder
+                    self.notify_progress()
+                    
+                    try:
+                        # E-Mails abrufen
+                        email_list = email_client.search_emails(
+                            query='ALL',
+                            folder=folder,
+                            limit=self.email_config.get('max_emails', 50)
+                        )
+                        
+                        for email_data in email_list:
+                            if self.stop_event.is_set():
+                                break
+                            
+                            try:
+                                subject = email_data.get('subject', '(Kein Betreff)')
+                                self.current_progress.current_email = subject
+                                
+                                # E-Mail formatieren
+                                content = self._format_email_content(email_data)
+                                
+                                # In Chunks aufteilen
+                                chunks = self._split_text(content)
+                                
+                                if chunks:
+                                    all_chunks.extend(chunks)
+                                    
+                                    # Source-Informationen erstellen
+                                    source_info = {
+                                        'file': subject,
+                                        'folder': folder,
+                                        'from': email_data.get('from', ''),
+                                        'date': email_data.get('date', ''),
+                                        'type': 'email'
+                                    }
+                                    sources.extend([source_info] * len(chunks))
+                                
+                                self.current_progress.processed_emails += 1
+                                self.notify_progress()
+                                
+                            except Exception as e:
+                                error_msg = f"Error processing email {subject}: {str(e)}"
+                                self.logger.error(error_msg)
+                                self.current_progress.errors.append(error_msg)
+                    
+                    except Exception as e:
+                        error_msg = f"Error accessing folder {folder}: {str(e)}"
+                        self.logger.error(error_msg)
+                        self.current_progress.errors.append(error_msg)
+                
+                # Abschluss
+                if not self.stop_event.is_set():
+                    # Wissensbasis aktualisieren (global)
+                    from app import knowledge_base
+                    knowledge_base.knowledge_chunks = all_chunks
+                    knowledge_base.document_sources = sources
+                    
+                    # Cache speichern
+                    self._save_knowledge_cache(all_chunks, sources)
+                    
+                    self.current_progress.status = EmailIndexingStatus.COMPLETED
+                    self.logger.info(f"Email indexing completed: {len(all_chunks)} chunks from {self.current_progress.processed_emails} emails")
+                else:
+                    self.current_progress.status = EmailIndexingStatus.IDLE
+                
+            except Exception as e:
+                self.current_progress.status = EmailIndexingStatus.ERROR
+                self.current_progress.error_message = str(e)
+                self.logger.error(f"Email indexing error: {str(e)}")
+        
+        finally:
+            self.current_progress.end_time = time.time()
+            self.current_progress.current_folder = ""
+            self.current_progress.current_email = ""
+            self.notify_progress()
+    
+    def _save_knowledge_cache(self, chunks: list, sources: list):
+        """Speichert die verarbeiteten E-Mail-Daten in der Datenbank"""
+        try:
+            from app import knowledge_base
+            
+            if knowledge_base.db:
+                conn = knowledge_base.db.connection
+                cursor = conn.cursor()
+                
+                # Gruppiere Chunks nach E-Mail
+                doc_chunks = {}
+                for i, chunk in enumerate(chunks):
+                    source = sources[i] if i < len(sources) else {'file': 'email', 'type': 'email'}
+                    doc_key = source.get('file', f'email_{i}')
+                    
+                    if doc_key not in doc_chunks:
+                        doc_chunks[doc_key] = {
+                            'chunks': [],
+                            'source': source
+                        }
+                    doc_chunks[doc_key]['chunks'].append(chunk)
+                
+                # Speichere Dokumente und Chunks
+                total_chunks = 0
+                for doc_key, doc_data in doc_chunks.items():
+                    source = doc_data['source']
+                    doc_chunks_list = doc_data['chunks']
+                    
+                    path = f"email://{source.get('folder', 'INBOX')}/{doc_key}"
+                    name = doc_key
+                    file_type = 'email'
+                    metadata = source
+                    
+                    # Prüfe ob Dokument bereits existiert
+                    cursor.execute("SELECT id FROM documents WHERE path = ?", (path,))
+                    existing = cursor.fetchone()
+                    
+                    if existing:
+                        doc_id = existing['id']
+                        try:
+                            cursor.execute("DELETE FROM chunks WHERE document_id = ?", (doc_id,))
+                            cursor.execute("DELETE FROM chunks_fts WHERE document_id = ?", (doc_id,))
+                            conn.commit()
+                        except Exception:
+                            conn.rollback()
+                        
+                        # Update metadata
+                        try:
+                            cursor.execute(
+                                """
+                                UPDATE documents SET name = ?, file_type = ?, updated_at = ?, metadata = ?
+                                WHERE id = ?
+                                """,
+                                (name, file_type, time.time(), json.dumps(metadata or {}), doc_id)
+                            )
+                            conn.commit()
+                        except Exception:
+                            conn.rollback()
+                    else:
+                        # Neues Dokument einfügen
+                        doc_id = knowledge_base.db.add_document(
+                            name=name,
+                            path=path,
+                            file_type=file_type,
+                            metadata=metadata
+                        )
+                    
+                    # Chunks hinzufügen
+                    try:
+                        for chunk_text in doc_chunks_list:
+                            knowledge_base.db.add_chunk(
+                                document_id=doc_id,
+                                content=chunk_text
+                            )
+                        total_chunks += len(doc_chunks_list)
+                    except Exception as e:
+                        self.logger.error(f"Error adding chunks: {str(e)}")
+                
+                self.logger.info(f"Saved {total_chunks} email chunks to database")
+            
+        except Exception as e:
+            self.logger.error(f"Error saving email cache: {str(e)}")
+
+
+# Globaler EmailIndexingManager
+email_indexing_manager = EmailIndexingManager()

--- a/frontend/app/settings/page.js
+++ b/frontend/app/settings/page.js
@@ -253,11 +253,46 @@ export default function SettingsPage() {
   const [nextcloudDisplayName, setNextcloudDisplayName] = useState('');
   const [nextcloudLoggingIn, setNextcloudLoggingIn] = useState(false);
 
+  // Email Indexing State
+  const [emailConfig, setEmailConfig] = useState({
+    imap_host: '',
+    imap_port: 993,
+    username: '',
+    password: '',
+    folders: 'INBOX',
+    max_emails: 50,
+    use_ssl: true
+  });
+  const [emailConfigStatus, setEmailConfigStatus] = useState('');
+  const [emailTestLoading, setEmailTestLoading] = useState(false);
+  const [emailIndexingMode, setEmailIndexingMode] = useState('manual');
+  const [emailIndexingAccountId, setEmailIndexingAccountId] = useState('');
+  const [emailIndexingStatus, setEmailIndexingStatus] = useState('idle');
+  const [emailIndexingProgress, setEmailIndexingProgress] = useState(0);
+  const [emailIndexingDetails, setEmailIndexingDetails] = useState({
+    processed: 0,
+    elapsed: 0,
+    current_folder: '',
+    message: ''
+  });
+
   useEffect(() => {
     if (typeof window !== 'undefined' && !briefingTalkWebhookUrl.trim()) {
       setBriefingTalkWebhookUrl(`${window.location.origin}/api/nextcloud/talk/webhook`);
     }
   }, [briefingTalkWebhookUrl]);
+
+  useEffect(() => {
+    if (briefingEmailAccounts.length > 0) {
+      setEmailIndexingMode((current) => current === 'manual' && !emailIndexingAccountId ? 'existing' : current);
+      if (!emailIndexingAccountId || !briefingEmailAccounts.some((account) => account.account_id === emailIndexingAccountId)) {
+        setEmailIndexingAccountId(briefingEmailAccounts[0].account_id);
+      }
+    } else if (emailIndexingMode === 'existing') {
+      setEmailIndexingMode('manual');
+      setEmailIndexingAccountId('');
+    }
+  }, [briefingEmailAccounts, emailIndexingAccountId, emailIndexingMode]);
 
   useEffect(() => {
     let cancelled = false;
@@ -372,6 +407,7 @@ export default function SettingsPage() {
     loadCalendarConfig();
     loadCalendarOptions();
     loadIndexingConfig();
+    loadEmailIndexingConfig();
     loadAllApis();
     updateStatus();
     // initial load of persistent indexing stats
@@ -929,6 +965,54 @@ export default function SettingsPage() {
     }
   };
 
+  const loadEmailIndexingConfig = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/config`);
+      if (res.ok) {
+        const config = await res.json();
+        // Don't display the password for security
+        setEmailConfig(prev => ({
+          ...prev,
+          imap_host: config.imap_host || '',
+          imap_port: config.imap_port || 993,
+          username: config.username || '',
+          folders: config.folders || 'INBOX',
+          max_emails: config.max_emails || 50,
+          use_ssl: config.use_ssl !== false
+          // password stays as-is (empty after load for security)
+        }));
+      }
+    } catch (err) {
+      console.error('Error loading email indexing config:', err);
+    }
+  };
+
+  const buildEmailIndexingPayload = () => {
+    const safeFolders = String(emailConfig.folders || 'INBOX').trim() || 'INBOX';
+    const safeMaxEmails = Number.isFinite(Number(emailConfig.max_emails)) ? Number(emailConfig.max_emails) : 50;
+
+    if (emailIndexingMode === 'existing' && emailIndexingAccountId) {
+      return {
+        account_id: emailIndexingAccountId,
+        folders: safeFolders,
+        max_emails: safeMaxEmails,
+        use_ssl: Boolean(emailConfig.use_ssl)
+      };
+    }
+
+    return {
+      email_config: {
+        imap_host: String(emailConfig.imap_host || '').trim(),
+        imap_port: Number.isFinite(Number(emailConfig.imap_port)) ? Number(emailConfig.imap_port) : 993,
+        username: String(emailConfig.username || '').trim(),
+        password: String(emailConfig.password || ''),
+        folders: safeFolders,
+        max_emails: safeMaxEmails,
+        use_ssl: Boolean(emailConfig.use_ssl)
+      }
+    };
+  };
+
   const saveIndexingConfig = async () => {
     try {
       const res = await fetch(`${API_BASE}/api/indexing/path`, {
@@ -1070,6 +1154,113 @@ export default function SettingsPage() {
       }
     } catch (err) {
       setIndexingStatus('error: ' + err.message);
+    }
+  };
+
+  // ========== Email Indexing Functions ==========
+  
+  const testEmailConnection = async () => {
+    setEmailTestLoading(true);
+    try {
+      const payload = emailIndexingMode === 'existing' && emailIndexingAccountId
+        ? { account_id: emailIndexingAccountId }
+        : { config: buildEmailIndexingPayload().email_config };
+
+      const res = await fetch(`${API_BASE}/api/email/test`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setEmailConfigStatus(data?.message || tr('Verbindung erfolgreich.', 'Connection successful.'));
+      } else {
+        const data = await res.json();
+        setEmailConfigStatus(tr('Fehler: ', 'Error: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    } finally {
+      setEmailTestLoading(false);
+    }
+  };
+
+  const saveEmailConfig = async () => {
+    try {
+      if (emailIndexingMode === 'existing' && emailIndexingAccountId) {
+        setEmailConfigStatus(tr('Für bestehende Konten ist kein separates Speichern nötig.', 'No separate save is needed for existing accounts.'));
+        return;
+      }
+
+      const res = await fetch(`${API_BASE}/api/email-indexing/config`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(emailConfig)
+      });
+      if (res.ok) {
+        setEmailConfigStatus(tr('E-Mail-Konfiguration erfolgreich gespeichert!', 'Email configuration saved successfully!'));
+      } else {
+        const data = await res.json();
+        setEmailConfigStatus(tr('Fehler beim Speichern: ', 'Error saving: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    }
+  };
+
+  const startEmailIndexing = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildEmailIndexingPayload())
+      });
+      
+      if (res.ok) {
+        setEmailIndexingStatus('running');
+        const progressInterval = setInterval(async () => {
+          try {
+            const res = await fetch(`${API_BASE}/api/email-indexing/progress`);
+            if (res.ok) {
+              const data = await res.json();
+              setEmailIndexingProgress(Math.round(data.progress_percentage || 0));
+              setEmailIndexingDetails({
+                processed: data.emails_processed || 0,
+                elapsed: Math.round(data.elapsed_time || 0),
+                current_folder: data.current_folder || '',
+                message: data.status_message || ''
+              });
+              
+              if (data.status === 'completed' || data.status === 'error') {
+                setEmailIndexingStatus(data.status);
+                clearInterval(progressInterval);
+              }
+            }
+          } catch (err) {
+            console.error('Error checking email indexing progress:', err);
+          }
+        }, 1000);
+      } else {
+        const data = await res.json();
+        setEmailIndexingStatus('error');
+        setEmailConfigStatus(tr('Fehler: ', 'Error: ') + (data.error || 'Unbekannter Fehler'));
+      }
+    } catch (err) {
+      setEmailIndexingStatus('error');
+      setEmailConfigStatus(tr('Fehler: ', 'Error: ') + err.message);
+    }
+  };
+
+  const stopEmailIndexing = async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/email-indexing/stop`, {
+        method: 'POST'
+      });
+      if (res.ok) {
+        setEmailIndexingStatus('stopped');
+      }
+    } catch (err) {
+      console.error('Error stopping email indexing:', err);
     }
   };
 
@@ -2887,6 +3078,231 @@ export default function SettingsPage() {
                               <div key={index} style={{marginBottom: '0.25rem'}}>• {error}</div>
                             ))}
                           </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="panel-section" style={{marginTop: '2rem'}}>
+                  <div className="section-title">{tr('E-Mail-Indexierung', 'Email Indexing')}</div>
+                  <p style={{fontSize: '0.9rem', color: 'var(--muted)', margin: '0.5rem 0'}}>
+                    {tr('Indexiere deine E-Mails für die semantische Suche', 'Index your emails for semantic search')}
+                  </p>
+
+                  <div className="input-group">
+                    <label>{tr('Quelle für die E-Mail-Indexierung', 'Email indexing source')}</label>
+                    <select
+                      value={emailIndexingMode}
+                      onChange={(e) => setEmailIndexingMode(e.target.value)}
+                    >
+                      <option value="existing">{tr('Gespeichertes Konto verwenden', 'Use saved account')}</option>
+                      <option value="manual">{tr('Eigenes Konto manuell angeben', 'Enter custom account')}</option>
+                    </select>
+                  </div>
+
+                  {emailIndexingMode === 'existing' ? (
+                    <>
+                      <div className="input-group">
+                        <label>{tr('Gespeichertes E-Mail-Konto', 'Saved email account')}</label>
+                        <select
+                          value={emailIndexingAccountId}
+                          onChange={(e) => setEmailIndexingAccountId(e.target.value)}
+                        >
+                          {briefingEmailAccounts.length === 0 ? (
+                            <option value="">{tr('Keine Konten verfügbar', 'No accounts available')}</option>
+                          ) : (
+                            briefingEmailAccounts.map((account) => (
+                              <option key={account.account_id} value={account.account_id}>
+                                {account.display_name}
+                              </option>
+                            ))
+                          )}
+                        </select>
+                        <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                          {tr('Es wird die unter APIs bereits gespeicherte Konfiguration verwendet. Manuelle IMAP-Daten sind dann nicht nötig.', 'The already saved API configuration is used. Manual IMAP details are not needed.')} 
+                        </small>
+                      </div>
+                    </>
+                  ) : (
+                    <>
+                      <div className="input-group">
+                        <label>IMAP Host</label>
+                        <input 
+                          type="text" 
+                          value={emailConfig.imap_host}
+                          onChange={(e) => setEmailConfig({...emailConfig, imap_host: e.target.value})}
+                          placeholder="imap.gmail.com"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>IMAP Port</label>
+                        <input 
+                          type="number" 
+                          value={emailConfig.imap_port}
+                          onChange={(e) => setEmailConfig({...emailConfig, imap_port: parseInt(e.target.value)})}
+                          placeholder="993"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>{tr('E-Mail-Adresse', 'Email Address')}</label>
+                        <input 
+                          type="email" 
+                          value={emailConfig.username}
+                          onChange={(e) => setEmailConfig({...emailConfig, username: e.target.value})}
+                          placeholder="your-email@example.com"
+                        />
+                      </div>
+
+                      <div className="input-group">
+                        <label>{tr('Passwort', 'Password')}</label>
+                        <input 
+                          type="password" 
+                          value={emailConfig.password}
+                          onChange={(e) => setEmailConfig({...emailConfig, password: e.target.value})}
+                          placeholder="••••••••"
+                        />
+                        <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                          {tr('Für Gmail: Verwende App-Passwort (nicht dein normales Passwort)', 'For Gmail: Use App Password (not your regular password)')}
+                        </small>
+                      </div>
+                    </>
+                  )}
+
+                  <div className="input-group">
+                    <label>{tr('Ordner (kommasepariert)', 'Folders (comma-separated)')}</label>
+                    <input 
+                      type="text" 
+                      value={emailConfig.folders}
+                      onChange={(e) => setEmailConfig({...emailConfig, folders: e.target.value})}
+                      placeholder="INBOX, Sent, Drafts"
+                    />
+                    <small style={{color: 'var(--muted)', display: 'block', marginTop: '0.25rem'}}>
+                      {tr('Welche E-Mail-Ordner sollen indexiert werden?', 'Which email folders should be indexed?')}
+                    </small>
+                  </div>
+
+                  <div className="input-group">
+                    <label>{tr('Max E-Mails pro Ordner', 'Max Emails per Folder')}</label>
+                    <input 
+                      type="number" 
+                      value={emailConfig.max_emails}
+                      onChange={(e) => setEmailConfig({...emailConfig, max_emails: parseInt(e.target.value)})}
+                      placeholder="50"
+                    />
+                  </div>
+
+                  <div className="input-group" style={{display: 'flex', alignItems: 'center'}}>
+                    <label style={{display: 'flex', alignItems: 'center', cursor: 'pointer', marginBottom: 0}}>
+                      <input 
+                        type="checkbox" 
+                        checked={emailConfig.use_ssl}
+                        onChange={(e) => setEmailConfig({...emailConfig, use_ssl: e.target.checked})}
+                        style={{marginRight: '0.5rem'}}
+                      />
+                      {tr('SSL/TLS verwenden', 'Use SSL/TLS')}
+                    </label>
+                  </div>
+
+                  <div className="button-group" style={{marginTop: '1.5rem'}}>
+                    <button className="btn secondary" onClick={testEmailConnection} disabled={emailTestLoading}>
+                      <i className="fas fa-flask" style={{marginRight: '0.5rem'}}></i>
+                      {emailTestLoading ? tr('Teste Verbindung...', 'Testing Connection...') : tr('Verbindung testen', 'Test Connection')}
+                    </button>
+                    {emailIndexingMode === 'manual' && (
+                      <button className="btn primary" onClick={saveEmailConfig} disabled={!emailConfig.imap_host || !emailConfig.username || !emailConfig.password}>
+                        <i className="fas fa-save" style={{marginRight: '0.5rem'}}></i>
+                        {tr('Manuelle Konfiguration speichern', 'Save manual config')}
+                      </button>
+                    )}
+                  </div>
+
+                  {emailConfigStatus && <div className={`status-text ${emailConfigStatus.includes('Fehler') ? 'error' : 'success'}`}>{emailConfigStatus}</div>}
+
+                  <div className="button-group" style={{marginTop: '1.5rem'}}>
+                    <button className="btn primary" onClick={startEmailIndexing} disabled={emailIndexingStatus === 'running'}>
+                      <i className="fas fa-envelope" style={{marginRight: '0.5rem'}}></i>
+                      {emailIndexingStatus === 'running' ? tr('E-Mail-Indexierung läuft...', 'Email Indexing...') : tr('E-Mail-Indexierung starten', 'Start Email Indexing')}
+                    </button>
+                    {emailIndexingStatus === 'running' && (
+                      <button className="btn secondary" onClick={stopEmailIndexing}>
+                        {tr('Stoppen', 'Stop')}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Email Indexing Progress */}
+                  {(emailIndexingStatus !== 'idle' || emailIndexingDetails.processed > 0) && (
+                    <div style={{marginTop: '1.5rem', padding: '1rem', background: 'var(--surface)', borderRadius: '8px', border: '1px solid var(--border)'}}>
+                      <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1rem'}}>
+                        <h4 style={{margin: 0, fontSize: '1rem', fontWeight: '600'}}>
+                          <i className="fas fa-chart-line" style={{marginRight: '0.5rem'}}></i>
+                          {tr('E-Mail-Indexierungsfortschritt', 'Email Indexing Progress')}
+                        </h4>
+                        <span style={{
+                          fontSize: '0.8rem',
+                          padding: '0.25rem 0.75rem',
+                          borderRadius: '12px',
+                          background: emailIndexingStatus === 'running' ? 'var(--primary)' : 
+                                     emailIndexingStatus === 'completed' ? 'var(--success)' : 
+                                     emailIndexingStatus === 'error' ? 'var(--error)' : 'var(--muted)',
+                          color: 'white',
+                          fontWeight: '500'
+                        }}>
+                          {emailIndexingStatus.toUpperCase()}
+                        </span>
+                      </div>
+
+                      {emailIndexingStatus === 'running' && (
+                        <div className="progress-bar-wrapper" style={{marginBottom: '1rem'}}>
+                          <div className="progress-bar" style={{
+                            height: '8px',
+                            background: 'var(--border)',
+                            borderRadius: '4px',
+                            overflow: 'hidden',
+                            position: 'relative'
+                          }}>
+                            <div className="progress-fill" style={{
+                              height: '100%',
+                              background: 'linear-gradient(90deg, var(--primary), var(--primary-light))',
+                              transition: 'width 0.5s ease',
+                              width: `${emailIndexingProgress}%`,
+                              borderRadius: '4px'
+                            }}></div>
+                          </div>
+                          <div style={{display: 'flex', justifyContent: 'space-between', fontSize: '0.8rem', color: 'var(--muted)', marginTop: '0.5rem'}}>
+                            <span>{emailIndexingProgress}% {tr('abgeschlossen', 'Complete')}</span>
+                            <span>{emailIndexingDetails.processed} {tr('E-Mails verarbeitet', 'Emails Processed')}</span>
+                          </div>
+                        </div>
+                      )}
+
+                      <div style={{display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(150px, 1fr))', gap: '1rem', marginBottom: '1rem'}}>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--primary)'}}>
+                            {emailIndexingDetails.processed}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('E-Mails verarbeitet', 'Emails Processed')}</div>
+                        </div>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--accent)'}}>
+                            {Math.floor((emailIndexingDetails.elapsed || 0) / 60)}:{((emailIndexingDetails.elapsed || 0) % 60).toString().padStart(2, '0')}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('Verstrichene Zeit', 'Time Elapsed')}</div>
+                        </div>
+                        <div style={{textAlign: 'center', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px'}}>
+                          <div style={{fontSize: '1.5rem', fontWeight: 'bold', color: 'var(--success)'}}>
+                            {emailIndexingDetails.current_folder || '--'}
+                          </div>
+                          <div style={{fontSize: '0.75rem', color: 'var(--muted)'}}>{tr('Aktueller Ordner', 'Current Folder')}</div>
+                        </div>
+                      </div>
+
+                      {emailIndexingDetails.message && (
+                        <div style={{marginBottom: '1rem', padding: '0.75rem', background: 'var(--background)', borderRadius: '6px', fontSize: '0.85rem', color: 'var(--muted)'}}>
+                          {emailIndexingDetails.message}
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
This adds a selectable source for email indexing so the settings page can reuse already configured email API accounts and only fall back to manual IMAP fields when needed.

Backend:
- Resolve selected account IDs server-side for indexing start and connection tests
- Accept manual IMAP configs for custom accounts

Frontend:
- Add an email indexing source switch
- Reuse the existing saved email accounts list
- Hide manual IMAP fields unless custom mode is selected
- Keep the indexing options and progress display intact