### PR TITLE
Restore new chat creation and harden chat runtime checks

### DIFF
--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -19,7 +19,7 @@ import { isChatModel, uniqueSortedModels } from '../../lib/modelUtils';
 import {
   CHAT_STORAGE_KEY, ACTIVE_CHAT_STORAGE_KEY, DISPLAY_NAME_STORAGE_KEY,
   BRIEFING_SEEN_KEY, TTS_PROVIDER_STORAGE_KEY, LOCATION_AUTO_RESOLVE_KEY,
-  createMessageId, buildChatTitleFromText,
+  createMessageId, createEmptyChat, buildChatTitleFromText,
   safeReadJson, buildFriendlyChatErrorMessage,
   normalizeTtsProvider, LANGUAGE_COMMANDS, THEME_COMMANDS, MODE_COMMANDS,
   NAMED_COLOR_COMMANDS, THEME_LABEL_KEY, DESIGN_COLOR_PRESETS
@@ -273,6 +273,7 @@ export default function HomePage() {
     setIsThinking(true);
     const abortController = new AbortController();
     requestAbortRef.current = abortController;
+    let assistantMessageId = null;
     try {
       const currentMessages = chats.find((chat) => chat.id === targetChatId)?.messages || [];
       const contextMessages = options.messageId ? currentMessages : [...currentMessages, { role: 'user', content: text, id: userMessageId }];
@@ -302,7 +303,7 @@ export default function HomePage() {
         insertMessageAfter(targetChatId, userMessageId, { role: 'assistant', content: errorMessage, id: createMessageId() });
         return;
       }
-      const assistantMessageId = createMessageId();
+      assistantMessageId = createMessageId();
       insertMessageAfter(targetChatId, userMessageId, { role: 'assistant', content: '', id: assistantMessageId });
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
@@ -373,7 +374,13 @@ export default function HomePage() {
             clearActiveThinkTool();
             document.getElementById('thinking-text') && (document.getElementById('thinking-text').textContent = '');
             setLiveTools(prev => { const n = {...prev}; delete n[assistantMessageId]; return n; });
-            setPendingToolConfirm({ confirmationId: event.confirmation_id, tool: event.tool, description: event.description });
+            setPendingToolConfirm({
+              confirmationId: event.confirmation_id,
+              tool: event.tool,
+              description: event.description,
+              chatId: targetChatId,
+              messageId: assistantMessageId,
+            });
           }
         }
       }
@@ -383,7 +390,11 @@ export default function HomePage() {
       const friendlyMessage = isTimeout
         ? '\u26a0\ufe0f Die Anfrage hat zu lange gedauert. Bitte versuche es mit einer k\u00fcrzeren oder einfacheren Formulierung erneut.'
         : (err?.message || '\u26a0\ufe0f Die Anfrage konnte nicht verarbeitet werden. Bitte versuche es erneut.');
-      updateMessageInChat(targetChatId, assistantMessageId, (msg) => ({ ...msg, content: (msg.content || '') + '\n\n' + friendlyMessage }));
+      if (assistantMessageId) {
+        updateMessageInChat(targetChatId, assistantMessageId, (msg) => ({ ...msg, content: (msg.content || '') + '\n\n' + friendlyMessage }));
+      } else {
+        insertMessageAfter(targetChatId, userMessageId, { role: 'assistant', content: friendlyMessage, id: createMessageId() });
+      }
     } finally {
       setIsThinking(false);
       setUploadedFiles([]);
@@ -887,8 +898,10 @@ export default function HomePage() {
                   try {
                     const res = await apiFetch('/api/tool/run', { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ confirmation_id: toolInfo.confirmationId, confirmed: true }) });
                     const data = await res.json();
-                    if (data.success) { insertMessageAfter(activeChatId, userMessageId, { role: 'assistant', content: `✅ Tool ausgef\u00fchrt:\n\`\`\`\n${data.result}\n\`\`\``, id: createMessageId() }); }
-                    else { insertMessageAfter(activeChatId, userMessageId, { role: 'assistant', content: `\u274c Fehler: ${data.error}`, id: createMessageId() }); }
+                    const resultContent = data.success
+                      ? `✅ Tool ausgef\u00fchrt:\n\`\`\`\n${data.result}\n\`\`\``
+                      : `\u274c Fehler: ${data.error}`;
+                    updateMessageInChat(toolInfo.chatId, toolInfo.messageId, (msg) => ({ ...msg, content: resultContent }));
                   } catch (e) { console.error('Tool confirm error:', e); }
                 }}>
                   <i className="fas fa-check"></i> {tr('Erlauben', 'Allow')}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -12,6 +12,7 @@ const eslintConfig = [
         caughtErrors: 'none',
         destructuredArrayIgnorePattern: '^_',
       }],
+      'no-undef': 'error',
       'react-hooks/exhaustive-deps': 'error',
       'no-console': 'off',
       'react/no-unescaped-entities': 'off',

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -33,3 +33,49 @@ def test_application_entry_loads_without_browser_errors():
             expect(page.locator('#login-pass')).to_be_visible()
         assert page_errors == []
         browser.close()
+
+
+def test_authenticated_user_can_create_new_chats_from_empty_state():
+    base_url = os.getenv('MYND_BROWSER_BASE_URL', 'http://127.0.0.1:3000').rstrip('/')
+    page_errors = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.on('pageerror', lambda error: page_errors.append(str(error)))
+        def fulfill_authenticated_api(route):
+            if route.request.url.endswith('/api/setup/status'):
+                payload = {'success': True, 'needs_setup': False}
+            elif route.request.url.endswith('/api/auth/me'):
+                payload = {
+                    'authenticated': True,
+                    'user': {'id': 'browser-smoke', 'username': 'browser-smoke', 'role': 'admin'},
+                }
+            else:
+                payload = {'success': True}
+            route.fulfill(json=payload)
+
+        page.route('**/api/**', fulfill_authenticated_api)
+        page.add_init_script(
+            """
+            localStorage.setItem('mynd_language', 'en');
+            localStorage.setItem('mynd_token_v1', 'browser-smoke-token');
+            localStorage.removeItem('mynd_chat_history_v1');
+            localStorage.removeItem('mynd_active_chat_v1');
+            """
+        )
+
+        response = page.goto(f'{base_url}/', wait_until='networkidle')
+
+        assert response is not None and response.ok
+        new_chat_button = page.locator('.primary-nav .nav-item').first
+        expect(new_chat_button).to_be_visible()
+        expect(page.locator('.landing')).to_be_visible()
+        initial_chat_count = page.locator('.history-item').count()
+
+        new_chat_button.click()
+
+        expect(page.locator('.history-item')).to_have_count(initial_chat_count + 1)
+        expect(page.locator('.landing')).to_be_visible()
+        assert page_errors == []
+        browser.close()


### PR DESCRIPTION
## Summary
- restore the missing `createEmptyChat` import that broke empty/new chat initialization
- bind streaming failures and tool confirmations to valid chat/message identifiers
- enable ESLint `no-undef` so missing identifiers fail CI
- add an authenticated browser regression test that creates a chat from an empty history

## Root cause
The previous dead-code cleanup removed `createEmptyChat` from the page imports even though three live chat paths still use it. The existing browser smoke test only covered the unauthenticated login page, so the authenticated empty-history crash was not exercised.

## Verification
- `make check` (108 passed, 3 skipped)
- production static browser smoke suite (2 passed)
- authenticated development-server chat regression (1 passed)

Closes #84