### PR TITLE
fix: landing page Enter/Send not creating chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ screenshots/*
 !screenshots/app-main.png
 !screenshots/chat-response.png
 quadratische_funktion.xlsx
+dogfood-output/

--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -83,12 +83,16 @@ export default function HomePage() {
 
   const appendMessageToChat = useCallback((chatId, message, originalUserText = null) => {
     const now = Date.now();
-    setChats((prevChats) => prevChats.map((chat) => {
-      if (chat.id !== chatId) return chat;
-      const nextMessages = [...(chat.messages || []), message];
-      const shouldUpdateTitle = chat.title === 'Neuer Chat' && message.role === 'user' && originalUserText;
-      return { ...chat, messages: nextMessages, title: shouldUpdateTitle ? buildChatTitleFromText(originalUserText) : chat.title, updatedAt: now };
-    }));
+    setChats((prevChats) => {
+      const found = prevChats.some(c => c.id === chatId);
+      if (!found) return prevChats;
+      return prevChats.map((chat) => {
+        if (chat.id !== chatId) return chat;
+        const nextMessages = [...(chat.messages || []), message];
+        const shouldUpdateTitle = chat.title === 'Neuer Chat' && message.role === 'user' && originalUserText;
+        return { ...chat, messages: nextMessages, title: shouldUpdateTitle ? buildChatTitleFromText(originalUserText) : chat.title, updatedAt: now };
+      });
+    });
   }, [setChats]);
 
   const updateMessageInChat = useCallback((chatId, messageId, updater) => {
@@ -244,7 +248,7 @@ export default function HomePage() {
       const targetId = activeChatId || createEmptyChat().id;
       if (!activeChatId) {
         const newChat = createEmptyChat();
-        setChats([newChat]);
+        setChats(prev => [newChat, ...prev]);
         setActiveChatId(newChat.id);
         queueMessage(text, newChat.id, { fromVoice: options.fromVoice });
         return;
@@ -256,7 +260,7 @@ export default function HomePage() {
     let targetChatId = options.chatId || activeChatId;
     if (!targetChatId) {
       const newChat = createEmptyChat();
-      setChats([newChat]);
+      setChats(prev => [newChat, ...prev]);
       setActiveChatId(newChat.id);
       targetChatId = newChat.id;
     }

--- a/frontend/components/Composer.js
+++ b/frontend/components/Composer.js
@@ -66,7 +66,7 @@ export default function Composer({
           value={inputValue}
           placeholder={''}
           onChange={(e) => setInputValue(e.target.value)}
-          onKeyPress={(e) => e.key === 'Enter' && !e.ctrlKey && onSend(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && !e.ctrlKey && onSend(e.target.value)}
         />
         <button
           type="button"

--- a/frontend/components/LandingScreen.js
+++ b/frontend/components/LandingScreen.js
@@ -50,7 +50,7 @@ export default function LandingScreen({
             value={inputValue}
             placeholder={t('askPlaceholder')}
             onChange={(e) => setInputValue(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && onSend(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && onSend(e.target.value)}
           />
           <button type="button" className={`voice-btn ${isListening ? 'listening' : ''}`}
             onClick={onStartVoiceInput}


### PR DESCRIPTION
Probleme:
- onKeyPress is deprecated and does not fire for Enter in some browsers
- setChats([newChat]) overwrites all existing chats (destructive)
- No guard when appendMessageToChat receives a non-existent chatId

Fixes:
- onKeyPress -> onKeyDown in LandingScreen and Composer
- setChats([newChat]) -> setChats(prev => [newChat, ...prev]) (functional updater)
- Safety guard in appendMessageToChat for unmatched chatId
