### PR TITLE
Publish landing page without domain restrictions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@
 OLLAMA_BASE_URL=http://127.0.0.1:11434
 OLLAMA_MODEL=gemma3:latest
 EMBEDDING_MODEL=nomic-embed-text
-# Comma-separated list of allowed CORS origins. Avoid * outside isolated development.
-CORS_ALLOWED_ORIGINS=http://127.0.0.1:3000,http://localhost:3000
+# Allow the browser frontend to call the backend from any URL or domain.
+CORS_ALLOWED_ORIGINS=*
 
 # Security boundaries for agent tools
 MYND_WORKSPACE_DIR=./data/workspace

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -30,7 +30,7 @@ def create_app(test_config=None):
 @flask_app.after_request
 def add_cors_headers(response):
     origin = request.headers.get('Origin', '')
-    raw = os.getenv('CORS_ALLOWED_ORIGINS', 'http://127.0.0.1:3000,http://localhost:3000')
+    raw = os.getenv('CORS_ALLOWED_ORIGINS', '*')
     allowed_origins = {v.strip() for v in raw.split(',') if v.strip()}
     if origin and ('*' in allowed_origins):
         response.headers['Access-Control-Allow-Origin'] = origin
@@ -44,16 +44,6 @@ def add_cors_headers(response):
     response.headers['X-Content-Type-Options'] = 'nosniff'
     response.headers['Referrer-Policy'] = 'same-origin'
     response.headers['X-Frame-Options'] = 'DENY'
-    response.headers['Content-Security-Policy'] = (
-        "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' 'unsafe-eval'; "
-        "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; "
-        "img-src 'self' data: https: http:; "
-        "font-src 'self' data: https://cdnjs.cloudflare.com; "
-        "connect-src 'self' http: https: ws: wss:; "
-        "media-src 'self' data: blob:; "
-        "frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-    )
     return response
 
 

--- a/frontend/app/(main)/layout.js
+++ b/frontend/app/(main)/layout.js
@@ -7,7 +7,7 @@ export default function MainLayout({ children }) {
   const { isSidebarCollapsed, canAnimate } = useSidebar();
 
   return (
-    <div className={`container ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}${!canAnimate ? ' no-animate' : ''}`}>
+    <div className={`container ${isSidebarCollapsed ? 'sidebar-collapsed' : ''}${!canAnimate ? ' no-animate' : ''}`} data-auth-view="workspace">
       <Sidebar />
       {children}
     </div>

--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -95,7 +95,6 @@ export default function RootLayout({ children }) {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
-        <meta httpEquiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: https: http:; connect-src 'self' http: https: ws: wss:; font-src 'self' https://cdnjs.cloudflare.com data:;" />
         <meta name="theme-color" content="#0f0f12" />
         <meta name="mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/frontend/components/AuthGate.js
+++ b/frontend/components/AuthGate.js
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState, useRef } from "react";
 import { usePathname, useRouter } from 'next/navigation';
 import './AuthGate.css';
 import { apiFetch } from '../lib/api';
+import LandingPage from './LandingPage';
 
 const LANGUAGE_KEY = 'mynd_language';
 const TOKEN_KEY = 'mynd_token_v1';
@@ -59,7 +60,7 @@ export default function AuthGate({ children }) {
 
   useEffect(() => {
     const langSet = (() => { try { return !!localStorage.getItem(LANGUAGE_KEY); } catch(e) { return true; } })();
-    if (!langSet && pathname !== '/language') {
+    if (!langSet && pathname !== '/' && pathname !== '/language') {
       guardedReplace('/language');
     }
   }, [pathname, guardedReplace]);
@@ -107,7 +108,7 @@ export default function AuthGate({ children }) {
 
   useEffect(() => {
     if (!ready) return;
-    if (pathname === '/language' || pathname?.startsWith('/setup') || pathname === '/login') return;
+    if (pathname === '/' || pathname === '/language' || pathname?.startsWith('/setup') || pathname === '/login') return;
     if (user && !forceOpen) return;
     guardedReplace('/login');
   }, [ready, pathname, user, forceOpen, guardedReplace]);
@@ -142,5 +143,6 @@ export default function AuthGate({ children }) {
   if (pathname?.startsWith('/setup')) return children;
   if (pathname === '/login') return children;
   if (user && !forceOpen) return children;
+  if (pathname === '/') return <LandingPage />;
   return null;
 }

--- a/frontend/components/LandingPage.css
+++ b/frontend/components/LandingPage.css
@@ -1,449 +1,398 @@
 html:has(.lp),
 html:has(.lp) body {
-  overflow: visible !important;
-  height: auto !important;
-  min-height: 100vh;
+  height: auto;
+  min-height: 100%;
+  overflow: visible;
+  scroll-behavior: smooth;
 }
 
 .lp {
-  --bg: #0a0a14;
-  --card: #12121e;
-  --card-border: #242438;
-  --card-radius: 16px;
-  --input-bg: #1a1a2e;
-  --text: #e2e8f0;
-  --muted: #8892a8;
-  --brand: var(--brand, #c97d3a);
-  --brand-glow: color-mix(in srgb, var(--brand, #c97d3a) 10%, transparent);
-  --glow: radial-gradient(ellipse 60% 40% at 50% 50%, var(--brand-glow), transparent);
-  background: var(--bg);
-  color: var(--text);
-  min-height: 100vh;
-  font-family: var(--font-space-grotesk, -apple-system, BlinkMacSystemFont, sans-serif);
-}
-
-@media (prefers-color-scheme: light) {
-  .lp {
-    --bg: #f1f5f9;
-    --card: #ffffff;
-    --card-border: #e2e8f0;
-    --input-bg: #e2e8f0;
-    --text: #0f172a;
-    --muted: #64748b;
-    --brand-glow: color-mix(in srgb, var(--brand, #c97d3a) 5%, transparent);
-  }
-  .lp-step-icon i, .lp-integration-item i {
-    color: #475569;
-  }
-  .lp-footer {
-    border-top-color: var(--card-border);
-  }
-}
-
-/* ── Nav ──────────────────────────────────── */
-.lp-nav {
-  position: fixed;
-  top: 0; left: 0; right: 0;
-  z-index: 100;
-  background: color-mix(in srgb, var(--bg) 80%, transparent);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  border-bottom: 1px solid var(--card-border);
-}
-
-.lp-nav-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0.75rem 2rem;
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-}
-
-.lp-logo {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 1.1rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-}
-
-.lp-logo-icon {
-  color: var(--brand);
-  font-size: 1.3rem;
-}
-
-.lp-nav-links {
-  display: flex;
-  gap: 1.5rem;
-  flex: 1;
-}
-
-.lp-nav-links button {
-  background: none;
-  border: none;
-  color: var(--muted);
-  font-size: 0.85rem;
-  cursor: pointer;
-  font-family: inherit;
-  transition: color 0.2s;
-  padding: 0;
-}
-
-.lp-nav-links button:hover {
-  color: var(--text);
-}
-
-.lp-nav-right {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.lp-lang-toggle {
-  background: var(--input-bg);
-  border: 1px solid var(--card-border);
-  color: var(--muted);
-  padding: 0.5rem 0.75rem;
-  border-radius: 8px;
-  font-size: 0.78rem;
-  font-weight: 600;
-  cursor: pointer;
-  font-family: inherit;
-  transition: all 0.2s;
-  line-height: 1;
-  min-width: 44px;
-  text-align: center;
-}
-
-.lp-lang-toggle:hover {
-  border-color: var(--brand);
-  color: var(--text);
-}
-
-/* ── Buttons ───────────────────────────────── */
-.lp-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.4rem;
-  padding: 0.6rem 1.2rem;
-  border-radius: 8px;
-  font-size: 0.85rem;
-  font-weight: 600;
-  cursor: pointer;
-  text-decoration: none;
-  font-family: inherit;
-  transition: all 0.2s;
-  border: 1px solid transparent;
-  line-height: 1;
-  white-space: nowrap;
-  min-height: 38px;
-}
-
-.lp-btn-primary {
-  background: var(--brand);
-  color: #fff;
-  border: none;
-}
-
-.lp-btn-primary:hover {
-  filter: brightness(1.1);
-}
-
-.lp-btn-secondary {
-  background: transparent;
-  border-color: var(--card-border);
-  color: var(--text);
-}
-
-.lp-btn-secondary:hover {
-  border-color: var(--muted);
-}
-
-/* ── Hero ──────────────────────────────────── */
-.lp-hero {
+  --lp-bg: #191816;
+  --lp-bg-deep: #11110f;
+  --lp-paper: #efe8dc;
+  --lp-paper-deep: #ded2c1;
+  --lp-ink: #25211c;
+  --lp-light: #f7f1e7;
+  --lp-muted: #a9a094;
+  --lp-line: rgba(239, 232, 220, 0.17);
+  --lp-line-dark: rgba(37, 33, 28, 0.16);
+  --lp-brand: #c97d3a;
+  --lp-brand-dark: #9b5424;
+  --lp-mono: var(--font-ibm-plex-mono), monospace;
   position: relative;
-  min-height: 90vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 6rem 2rem 3rem;
+  min-height: 100vh;
+  overflow: hidden;
+  color: var(--lp-light);
+  background: var(--lp-bg);
+  font-family: var(--font-space-grotesk), sans-serif;
+  isolation: isolate;
 }
 
-.lp-hero::before {
-  content: '';
-  position: absolute;
+.lp::before {
+  position: fixed;
   inset: 0;
-  background: var(--glow);
+  z-index: -1;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 180 180' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.9' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='.35'/%3E%3C/svg%3E");
+  content: '';
+  opacity: 0.028;
   pointer-events: none;
 }
 
-.lp-hero-content {
-  position: relative;
-  text-align: center;
-  max-width: 600px;
-  animation: lpFadeIn 0.5s ease-out;
-}
+.lp a,
+.lp button { -webkit-tap-highlight-color: transparent; }
+.lp a:focus-visible,
+.lp button:focus-visible { outline: 2px solid var(--lp-brand); outline-offset: 4px; }
 
-.lp-hero-title {
-  font-size: clamp(2.2rem, 6vw, 3.8rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  line-height: 1.12;
-  margin: 0 0 0.75rem;
+.lp-skip {
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+  z-index: 1000;
+  padding: .7rem 1rem;
+  color: var(--lp-ink);
+  background: var(--lp-paper);
+  transform: translateY(-180%);
+  transition: transform .2s ease;
 }
+.lp-skip:focus { transform: translateY(0); }
 
-.lp-hero-title em {
-  font-style: normal;
-  color: var(--brand);
+/* Navigation */
+.lp-nav {
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 20;
+  border-bottom: 1px solid var(--lp-line);
 }
-
-.lp-hero-sub {
-  font-size: 0.95rem;
-  color: var(--muted);
-  line-height: 1.7;
-  margin: 0 0 1.75rem;
-}
-
-.lp-hero-actions {
-  display: flex;
-  gap: 0.75rem;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-/* ── Cards (shared section style) ──────────── */
-.lp-card-section {
-  padding: 4rem 2rem;
-}
-
-.lp-card-section-inner {
-  max-width: 1100px;
-  margin: 0 auto;
-}
-
-.lp-card-section-header {
-  text-align: center;
-  margin-bottom: 2.5rem;
-}
-
-.lp-card-section-header h2 {
-  font-size: clamp(1.3rem, 3vw, 1.7rem);
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin: 0 0 0.35rem;
-}
-
-.lp-card-section-header p {
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin: 0;
-}
-
-/* ── Feature Cards ─────────────────────────── */
-.lp-card-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.75rem;
-}
-
-.lp-card {
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: var(--card-radius);
-  padding: 1.5rem;
-  transition: border-color 0.2s;
-}
-
-.lp-card:hover {
-  border-color: color-mix(in srgb, var(--brand) 25%, var(--card-border));
-}
-
-.lp-card-icon {
-  font-size: 1.1rem;
-  color: var(--brand);
-  margin-bottom: 0.75rem;
-}
-
-.lp-card h3 {
-  font-size: 0.85rem;
-  font-weight: 600;
-  margin: 0 0 0.3rem;
-}
-
-.lp-card p {
-  font-size: 0.78rem;
-  color: var(--muted);
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* ── Steps ─────────────────────────────────── */
-.lp-steps {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
-}
-
-.lp-step {
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: var(--card-radius);
-  padding: 1.5rem;
-  text-align: center;
-}
-
-.lp-step-icon {
-  width: 38px;
-  height: 38px;
-  border-radius: 10px;
-  display: grid;
-  place-items: center;
-  font-size: 0.95rem;
-  color: var(--brand);
-  background: var(--input-bg);
-  margin: 0 auto 0.75rem;
-}
-
-.lp-step h3 {
-  font-size: 0.82rem;
-  font-weight: 600;
-  margin: 0 0 0.25rem;
-}
-
-.lp-step p {
-  font-size: 0.75rem;
-  color: var(--muted);
-  line-height: 1.5;
-  margin: 0;
-}
-
-/* ── Numbers ───────────────────────────────── */
-.lp-numbers {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
-  margin-bottom: 2.5rem;
-}
-
-.lp-number-item {
-  text-align: center;
-  padding: 1.75rem 1rem;
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: var(--card-radius);
-}
-
-.lp-number-value {
-  font-size: 1.8rem;
-  font-weight: 800;
-  color: var(--brand);
-  letter-spacing: -0.02em;
-  margin-bottom: 0.15rem;
-}
-
-.lp-number-label {
-  font-size: 0.75rem;
-  color: var(--muted);
-}
-
-/* ── Integrations Overview ─────────────────── */
-.lp-integrations {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0.75rem;
-}
-
-.lp-integration-item {
+.lp-nav-inner {
+  width: min(1280px, calc(100% - 64px));
+  height: 76px;
+  margin: auto;
   display: flex;
   align-items: center;
-  gap: 0.65rem;
-  padding: 0.9rem 1rem;
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: var(--card-radius);
-  transition: border-color 0.2s;
 }
-
-.lp-integration-item:hover {
-  border-color: color-mix(in srgb, var(--brand) 25%, var(--card-border));
+.lp-logo {
+  display: inline-flex;
+  align-items: center;
+  gap: .68rem;
+  color: inherit;
+  font-size: 1.08rem;
+  font-weight: 650;
+  letter-spacing: .14em;
+  text-decoration: none;
 }
+.lp-logo-mark,
+.lp-core-mark {
+  width: 17px;
+  height: 17px;
+  display: inline-block;
+  border: 2px solid var(--lp-brand);
+  transform: rotate(45deg);
+  box-shadow: inset 0 0 0 3px var(--lp-bg);
+  background: var(--lp-brand);
+}
+.lp-nav-links {
+  display: flex;
+  gap: clamp(1.4rem, 3vw, 2.8rem);
+  margin-left: auto;
+}
+.lp-nav-links a {
+  color: var(--lp-muted);
+  font-size: .82rem;
+  text-decoration: none;
+  transition: color .2s ease;
+}
+.lp-nav-links a:hover { color: var(--lp-light); }
+.lp-nav-actions { display: flex; align-items: center; gap: 1.4rem; margin-left: clamp(2rem, 5vw, 4.5rem); }
+.lp-language {
+  display: flex;
+  align-items: center;
+  gap: .48rem;
+  border: 0;
+  color: #756e65;
+  background: transparent;
+  font: 500 .68rem/1 var(--lp-mono);
+  cursor: pointer;
+}
+.lp-language i { width: 1px; height: 12px; background: #5f5951; }
+.lp-language .active { color: var(--lp-light); }
+.lp-signin {
+  display: inline-flex;
+  align-items: center;
+  gap: .7rem;
+  color: var(--lp-light);
+  font-size: .8rem;
+  font-weight: 550;
+  text-decoration: none;
+}
+.lp-signin i { color: var(--lp-brand); font-size: .65rem; transition: transform .2s ease; }
+.lp-signin:hover i { transform: translateX(4px); }
 
-.lp-integration-item i {
-  width: 28px;
-  height: 28px;
-  border-radius: 7px;
+/* Hero */
+.lp-hero {
+  position: relative;
+  min-height: 780px;
+  background:
+    radial-gradient(circle at 74% 43%, rgba(201, 125, 58, .09), transparent 26%),
+    linear-gradient(108deg, var(--lp-bg) 0 58%, var(--lp-bg-deep) 58% 100%);
+}
+.lp-hero::after {
+  position: absolute;
+  inset: 76px calc(50% - 1px) 0 auto;
+  width: 1px;
+  background: linear-gradient(transparent, var(--lp-line) 20%, var(--lp-line) 82%, transparent);
+  content: '';
+}
+.lp-hero-grid {
+  width: min(1280px, calc(100% - 64px));
+  min-height: 780px;
+  margin: auto;
+  padding-top: 76px;
   display: grid;
-  place-items: center;
-  font-size: 0.75rem;
-  color: var(--brand);
-  background: var(--input-bg);
-  flex-shrink: 0;
+  grid-template-columns: .95fr 1.05fr;
+  align-items: center;
 }
-
-.lp-integration-item span {
-  font-size: 0.82rem;
-  font-weight: 500;
+.lp-hero-copy {
+  max-width: 620px;
+  padding: 5rem clamp(2rem, 5vw, 6rem) 3rem 0;
+  animation: lp-rise .75s cubic-bezier(.2,.7,.2,1) both;
 }
-
-/* ── CTA ───────────────────────────────────── */
-.lp-cta {
-  text-align: center;
-  padding: 5rem 2rem;
+.lp-eyebrow,
+.lp-kicker {
+  color: var(--lp-brand);
+  font: 500 .7rem/1.4 var(--lp-mono);
+  letter-spacing: .13em;
+  text-transform: uppercase;
 }
-
-.lp-cta h2 {
-  font-size: clamp(1.2rem, 2.5vw, 1.6rem);
-  font-weight: 700;
-  margin: 0 0 0.35rem;
+.lp-eyebrow { display: flex; align-items: center; gap: .65rem; margin-bottom: 2rem; }
+.lp-eyebrow span { width: 24px; height: 1px; background: var(--lp-brand); }
+.lp-hero h1 {
+  max-width: 570px;
+  margin: 0;
+  font-size: clamp(3rem, 5.2vw, 5.8rem);
+  font-weight: 475;
+  letter-spacing: -.065em;
+  line-height: .97;
 }
-
-.lp-cta p {
-  color: var(--muted);
-  font-size: 0.85rem;
-  margin: 0 0 1.5rem;
+.lp-hero h1 em { display: block; color: var(--lp-brand); font-style: normal; }
+.lp-hero-lede {
+  max-width: 540px;
+  margin: 2rem 0 0;
+  color: var(--lp-muted);
+  font-size: clamp(1rem, 1.35vw, 1.16rem);
+  line-height: 1.7;
 }
-
-/* ── Footer ────────────────────────────────── */
-.lp-footer {
-  border-top: 1px solid var(--card-border);
-  padding: 2.5rem 2rem;
-  text-align: center;
+.lp-hero-actions { display: flex; align-items: center; gap: 1.8rem; margin-top: 2.2rem; }
+.lp-primary-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 1.4rem;
+  min-height: 52px;
+  padding: 0 1.35rem;
+  border: 1px solid var(--lp-brand);
+  color: #fff8ef;
+  background: var(--lp-brand-dark);
+  font-size: .84rem;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: 6px 6px 0 rgba(201, 125, 58, .16);
+  transition: background .2s ease, box-shadow .2s ease, transform .2s ease;
 }
-
-.lp-footer-inner {
-  max-width: 1100px;
-  margin: 0 auto;
+.lp-primary-cta:hover { background: var(--lp-brand); box-shadow: 3px 3px 0 rgba(201, 125, 58, .22); transform: translate(2px, 2px); }
+.lp-primary-cta i { font-size: .7rem; }
+.lp-text-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: .65rem;
+  border-bottom: 1px solid #665e55;
+  padding: .4rem 0;
+  color: var(--lp-light);
+  font-size: .78rem;
+  text-decoration: none;
 }
+.lp-text-cta i { color: var(--lp-brand); font-size: .62rem; }
+.lp-hero-note { margin-top: 1.5rem; color: #777066; font: 400 .66rem/1.5 var(--lp-mono); }
+.lp-hero-note i { margin-right: .5rem; color: var(--lp-brand); }
 
-.lp-footer p {
-  color: var(--muted);
-  font-size: 0.75rem;
-  margin: 0.25rem 0 0;
-  opacity: 0.6;
+/* Context constellation */
+.lp-constellation { position: relative; width: min(46vw, 620px); aspect-ratio: 1; justify-self: end; animation: lp-appear 1s .2s ease both; }
+.lp-orbit { position: absolute; left: 50%; top: 50%; border: 1px solid var(--lp-line); border-radius: 50%; transform: translate(-50%, -50%); }
+.lp-orbit-one { width: 34%; height: 34%; }
+.lp-orbit-two { width: 61%; height: 61%; border-style: dashed; }
+.lp-orbit-three { width: 88%; height: 88%; }
+.lp-orbit-two::before,
+.lp-orbit-three::before { position: absolute; inset: -3px auto auto 50%; width: 5px; height: 5px; border-radius: 50%; background: var(--lp-brand); content: ''; box-shadow: 0 0 12px var(--lp-brand); }
+.lp-core {
+  position: absolute;
+  left: 50%; top: 50%;
+  width: 128px; height: 128px;
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  border: 1px solid rgba(201, 125, 58, .55);
+  background: rgba(24, 23, 21, .88);
+  transform: translate(-50%, -50%) rotate(45deg);
+  box-shadow: 0 0 60px rgba(201, 125, 58, .12);
 }
-
-/* ── Animation ─────────────────────────────── */
-@keyframes lpFadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
+.lp-core > * { transform: rotate(-45deg); }
+.lp-core-mark { width: 18px; height: 18px; margin: -12px 0 15px; box-shadow: inset 0 0 0 3px var(--lp-bg); }
+.lp-core strong { font-size: 1rem; letter-spacing: .12em; }
+.lp-core small { margin-top: .32rem; color: var(--lp-muted); font: .52rem/1 var(--lp-mono); letter-spacing: .08em; }
+.lp-node {
+  position: absolute;
+  display: flex; align-items: center; gap: .48rem;
+  padding: .58rem .72rem;
+  border: 1px solid var(--lp-line);
+  color: #cbc3b8;
+  background: rgba(24, 23, 21, .92);
+  font: 400 .6rem/1 var(--lp-mono);
+  box-shadow: 0 8px 24px rgba(0,0,0,.12);
 }
+.lp-node i { width: 15px; color: var(--lp-brand); text-align: center; }
+.lp-node-chat { top: 5%; left: 44%; }
+.lp-node-knowledge { top: 22%; right: 3%; }
+.lp-node-tasks { top: 65%; right: 3%; }
+.lp-node-home { bottom: 4%; left: 43%; }
+.lp-node-photos { top: 69%; left: 1%; }
+.lp-node-spotify { top: 24%; left: 2%; }
+.lp-node-discord { top: 45%; right: -4%; }
+.lp-signal { position: absolute; width: 5px; height: 5px; border-radius: 50%; background: var(--lp-brand); box-shadow: 0 0 10px var(--lp-brand); animation: lp-pulse 2.5s ease-in-out infinite; }
+.lp-signal-a { top: 36%; left: 28%; }
+.lp-signal-b { top: 61%; right: 27%; animation-delay: .8s; }
+.lp-signal-c { bottom: 22%; left: 37%; animation-delay: 1.5s; }
 
-/* ── Responsive ────────────────────────────── */
-@media (max-width: 768px) {
+/* Proof */
+.lp-proof { border-block: 1px solid var(--lp-line-dark); color: var(--lp-ink); background: var(--lp-paper-deep); }
+.lp-proof-inner { width: min(1280px, calc(100% - 64px)); min-height: 110px; margin: auto; display: grid; grid-template-columns: repeat(3, 1fr); }
+.lp-proof p { display: flex; align-items: center; gap: 1rem; margin: 0; padding: 1.4rem clamp(1rem, 3vw, 3rem); border-right: 1px solid var(--lp-line-dark); }
+.lp-proof p:first-child { padding-left: 0; }
+.lp-proof p:last-child { border: 0; }
+.lp-proof i { color: var(--lp-brand-dark); font-size: 1.05rem; }
+.lp-proof span { display: flex; flex-direction: column; gap: .3rem; color: #6c6257; font: .62rem/1.3 var(--lp-mono); }
+.lp-proof strong { color: var(--lp-ink); font: 600 .86rem/1.2 var(--font-space-grotesk); }
+
+/* Feature narrative */
+.lp-features { padding: clamp(5rem, 10vw, 9rem) max(32px, calc((100vw - 1280px) / 2)); color: var(--lp-ink); background: var(--lp-paper); }
+.lp-section-intro { display: grid; grid-template-columns: .55fr 1fr 1fr; gap: 3rem; align-items: start; margin-bottom: 5rem; }
+.lp-section-intro .lp-kicker { color: var(--lp-brand-dark); padding-top: .55rem; }
+.lp-section-intro h2,
+.lp-integrations h2,
+.lp-privacy h2,
+.lp-final h2 { margin: 0; font-size: clamp(2.3rem, 4.4vw, 4.6rem); font-weight: 475; letter-spacing: -.055em; line-height: 1; }
+.lp-section-intro > p:last-child { max-width: 450px; margin: .35rem 0 0; color: #6e6459; font-size: 1rem; line-height: 1.7; }
+.lp-feature-list { border-top: 1px solid var(--lp-line-dark); }
+.lp-feature { min-height: 178px; display: grid; grid-template-columns: 72px 80px minmax(260px, 1fr) .7fr; gap: 1.5rem; align-items: center; border-bottom: 1px solid var(--lp-line-dark); transition: background .25s ease, padding .25s ease; }
+.lp-feature:hover { padding-inline: 1rem; background: rgba(255,255,255,.25); }
+.lp-feature-index { color: #9d9183; font: .65rem/1 var(--lp-mono); }
+.lp-feature-icon { width: 50px; height: 50px; display: grid; place-items: center; border: 1px solid rgba(155,84,36,.38); color: var(--lp-brand-dark); transform: rotate(45deg); }
+.lp-feature-icon i { transform: rotate(-45deg); }
+.lp-feature-copy h3 { margin: 0 0 .6rem; font-size: clamp(1.25rem, 2vw, 1.8rem); font-weight: 560; letter-spacing: -.03em; }
+.lp-feature-copy p { max-width: 650px; margin: 0; color: #74695d; font-size: .91rem; line-height: 1.65; }
+.lp-feature-detail { display: flex; align-items: center; gap: .7rem; justify-self: end; color: #766c61; font: .6rem/1.4 var(--lp-mono); text-transform: uppercase; letter-spacing: .07em; }
+.lp-feature-detail span { width: 22px; height: 1px; background: var(--lp-brand-dark); }
+
+/* Integration rail */
+.lp-integrations { padding: clamp(5rem, 9vw, 8rem) max(32px, calc((100vw - 1280px) / 2)); background: #20201d; }
+.lp-integrations-head { display: grid; grid-template-columns: 1.25fr .75fr; gap: 5rem; align-items: end; margin-bottom: 4rem; }
+.lp-integrations .lp-kicker { margin-bottom: 1.2rem; }
+.lp-integrations-head > p { margin: 0 0 .4rem; color: var(--lp-muted); font-size: .95rem; line-height: 1.7; }
+.lp-integration-rail { display: grid; grid-template-columns: repeat(4, 1fr); border-block: 1px solid var(--lp-line); }
+.lp-integration { min-height: 120px; display: flex; align-items: center; gap: 1rem; padding: 1.3rem; border-right: 1px solid var(--lp-line); border-bottom: 1px solid var(--lp-line); transition: background .2s ease; }
+.lp-integration:nth-child(4n) { border-right: 0; }
+.lp-integration:nth-child(n+5) { border-bottom: 0; }
+.lp-integration:hover { background: rgba(201, 125, 58, .07); }
+.lp-integration > i { width: 42px; color: var(--lp-brand); font-size: 1.35rem; text-align: center; }
+.lp-integration h3 { margin: 0 0 .35rem; font-size: .9rem; font-weight: 600; }
+.lp-integration p { margin: 0; color: #8f877d; font: .56rem/1.5 var(--lp-mono); }
+
+/* Privacy */
+.lp-privacy { min-height: 680px; display: grid; grid-template-columns: 1fr 1fr; color: var(--lp-ink); background: var(--lp-paper-deep); }
+.lp-privacy-visual { position: relative; min-height: 620px; overflow: hidden; border-right: 1px solid var(--lp-line-dark); background: linear-gradient(135deg, rgba(155,84,36,.05), transparent 55%); }
+.lp-vault-ring { position: absolute; left: 50%; top: 50%; border: 1px solid rgba(155,84,36,.3); border-radius: 50%; transform: translate(-50%,-50%); }
+.lp-vault-ring-outer { width: min(36vw, 460px); height: min(36vw, 460px); border-style: dashed; animation: lp-spin 55s linear infinite; }
+.lp-vault-ring-inner { width: min(23vw, 290px); height: min(23vw, 290px); }
+.lp-vault-core { position: absolute; left: 50%; top: 50%; width: 116px; height: 116px; display: grid; place-items: center; border: 1px solid var(--lp-brand-dark); color: var(--lp-brand-dark); background: rgba(239,232,220,.6); transform: translate(-50%,-50%) rotate(45deg); }
+.lp-vault-core i { font-size: 1.65rem; transform: rotate(-45deg); }
+.lp-vault-label { position: absolute; padding: .45rem .6rem; border: 1px solid var(--lp-line-dark); color: #756a5d; background: var(--lp-paper-deep); font: .55rem/1 var(--lp-mono); letter-spacing: .12em; }
+.lp-vault-label-one { top: 19%; left: 46%; }
+.lp-vault-label-two { top: 53%; right: 13%; }
+.lp-vault-label-three { bottom: 18%; left: 20%; }
+.lp-privacy-copy { align-self: center; max-width: 650px; padding: 5rem clamp(2rem, 7vw, 7rem); }
+.lp-privacy-copy .lp-kicker { margin-bottom: 1.35rem; color: var(--lp-brand-dark); }
+.lp-privacy-copy > p:not(.lp-kicker) { margin: 2rem 0 0; color: #695f54; font-size: 1rem; line-height: 1.75; }
+.lp-privacy ul { margin: 2.4rem 0 0; padding: 0; list-style: none; }
+.lp-privacy li { display: flex; gap: .85rem; align-items: center; padding: .85rem 0; border-bottom: 1px solid var(--lp-line-dark); color: #514940; font-size: .8rem; }
+.lp-privacy li i { color: var(--lp-brand-dark); font-size: .65rem; }
+
+/* Final / Footer */
+.lp-final { display: flex; flex-direction: column; align-items: center; padding: clamp(5rem, 10vw, 9rem) 2rem; text-align: center; background: var(--lp-bg-deep); }
+.lp-final h2 { margin-top: 1.25rem; }
+.lp-final-cta { margin-top: 2.5rem; }
+.lp-footer { min-height: 90px; width: min(1280px, calc(100% - 64px)); margin: auto; display: flex; align-items: center; justify-content: space-between; border-top: 1px solid var(--lp-line); color: #777066; background: var(--lp-bg); font: .6rem/1 var(--lp-mono); }
+.lp-footer .lp-logo { color: var(--lp-light); font-family: var(--font-space-grotesk); }
+.lp-footer .lp-logo-mark { width: 13px; height: 13px; }
+.lp-footer a:last-child { color: #91897f; text-decoration: none; }
+
+@keyframes lp-rise { from { opacity: 0; transform: translateY(18px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes lp-appear { from { opacity: 0; transform: scale(.96); } to { opacity: 1; transform: scale(1); } }
+@keyframes lp-pulse { 0%,100% { opacity: .25; transform: scale(.7); } 50% { opacity: 1; transform: scale(1.25); } }
+@keyframes lp-spin { to { transform: translate(-50%,-50%) rotate(360deg); } }
+
+@media (max-width: 980px) {
+  .lp-nav-inner, .lp-hero-grid, .lp-proof-inner, .lp-footer { width: min(100% - 40px, 1280px); }
   .lp-nav-links { display: none; }
-  .lp-nav-inner { padding: 0.6rem 1.25rem; }
-  .lp-hero { padding: 5rem 1.25rem 2.5rem; min-height: 80vh; }
-  .lp-card-section { padding: 3rem 1.25rem; }
-  .lp-card-grid { grid-template-columns: 1fr; }
-  .lp-steps { grid-template-columns: repeat(2, 1fr); }
-  .lp-numbers { grid-template-columns: repeat(2, 1fr); }
-  .lp-integrations { grid-template-columns: repeat(2, 1fr); }
+  .lp-nav-actions { margin-left: auto; }
+  .lp-hero { min-height: auto; background: var(--lp-bg); }
+  .lp-hero::after { display: none; }
+  .lp-hero-grid { min-height: auto; padding: 140px 0 80px; grid-template-columns: 1fr; gap: 3rem; }
+  .lp-hero-copy { max-width: 720px; padding: 0; }
+  .lp-constellation { width: min(80vw, 600px); justify-self: center; }
+  .lp-section-intro { grid-template-columns: 1fr 1.4fr; }
+  .lp-section-intro > p:last-child { grid-column: 2; }
+  .lp-feature { grid-template-columns: 48px 64px 1fr; }
+  .lp-feature-detail { display: none; }
+  .lp-integration-rail { grid-template-columns: repeat(2, 1fr); }
+  .lp-integration:nth-child(2n) { border-right: 0; }
+  .lp-integration:nth-child(4n) { border-right: 0; }
+  .lp-integration:nth-child(n+5) { border-bottom: 1px solid var(--lp-line); }
+  .lp-integration:nth-child(n+7) { border-bottom: 0; }
+  .lp-privacy { grid-template-columns: .8fr 1.2fr; }
 }
 
-@media (max-width: 480px) {
-  .lp-steps { grid-template-columns: 1fr; }
-  .lp-integrations { grid-template-columns: 1fr; }
+@media (max-width: 700px) {
+  .lp-nav-inner { height: 66px; }
+  .lp-signin-nav { padding-left: .8rem; border-left: 1px solid var(--lp-line); }
+  .lp-language { display: none; }
+  .lp-hero-grid { padding-top: 118px; }
+  .lp-hero h1 { font-size: clamp(2.8rem, 13vw, 4.4rem); }
+  .lp-hero-actions { align-items: flex-start; flex-direction: column; gap: 1rem; }
+  .lp-hero-note { margin-top: 1.8rem; }
+  .lp-constellation { width: 108vw; margin-left: -4vw; }
+  .lp-node { padding: .46rem .55rem; font-size: .52rem; }
+  .lp-node-discord { right: 3%; }
+  .lp-proof-inner { grid-template-columns: 1fr; }
+  .lp-proof p, .lp-proof p:first-child { min-height: 82px; padding: 1rem 0; border-right: 0; border-bottom: 1px solid var(--lp-line-dark); }
+  .lp-section-intro { grid-template-columns: 1fr; gap: 1.2rem; margin-bottom: 3rem; }
+  .lp-section-intro > p:last-child { grid-column: auto; }
+  .lp-feature { min-height: 0; padding: 2rem 0; grid-template-columns: 44px 1fr; gap: 1rem; }
+  .lp-feature:hover { padding-inline: 0; }
+  .lp-feature-index { display: none; }
+  .lp-feature-icon { grid-row: 1; width: 38px; height: 38px; }
+  .lp-feature-copy { grid-column: 2; }
+  .lp-integrations-head { grid-template-columns: 1fr; gap: 1.5rem; }
+  .lp-integration-rail { grid-template-columns: 1fr; }
+  .lp-integration, .lp-integration:nth-child(2n), .lp-integration:nth-child(4n), .lp-integration:nth-child(n+7) { min-height: 92px; border-right: 0; border-bottom: 1px solid var(--lp-line); }
+  .lp-integration:last-child { border-bottom: 0; }
+  .lp-privacy { grid-template-columns: 1fr; }
+  .lp-privacy-visual { min-height: 440px; border-right: 0; border-bottom: 1px solid var(--lp-line-dark); }
+  .lp-vault-ring-outer { width: 340px; height: 340px; }
+  .lp-vault-ring-inner { width: 220px; height: 220px; }
+  .lp-privacy-copy { padding: 4.5rem 24px; }
+  .lp-footer { min-height: 150px; flex-direction: column; justify-content: center; gap: 1.1rem; text-align: center; }
+}
+
+@media (prefers-color-scheme: light) {
+  .lp-nav { background: rgba(25,24,22,.94); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:has(.lp), html:has(.lp) body { scroll-behavior: auto; }
+  .lp-hero-copy, .lp-constellation, .lp-signal, .lp-vault-ring-outer { animation: none; }
 }

--- a/frontend/components/LandingPage.js
+++ b/frontend/components/LandingPage.js
@@ -1,203 +1,244 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import './LandingPage.css';
-
-const FEATURES = [
-  { icon: 'fa-brain', title: 'KI-Chat', desc: 'Frag deine Dokumente, E-Mails und Dateien – MYND versteht Kontext und liefert Antworten.' },
-  { icon: 'fa-search', title: 'Semantische Suche', desc: 'Durchsuche tausende Fotos, PDFs und Notizen in Sekunden.' },
-  { icon: 'fa-home', title: 'Smart Home', desc: 'Steuere Lichter, Heizung und Geräte per Sprachbefehl.' },
-  { icon: 'fa-cloud', title: 'Nextcloud', desc: 'Kalender, Aufgaben, Kontakte und Dateien zentral angebunden.' },
-  { icon: 'fa-database', title: 'TrueNAS', desc: 'Überwache Speicherpools, Dienste und Container.' },
-  { icon: 'fa-microchip', title: 'Lokale KI', desc: 'Alle Berechnungen auf deinem Rechner. Maximale Privatsphäre.' }
-];
-
-const STEPS = [
-  { icon: 'fa-server', title: 'Backend starten', desc: 'Läuft auf deinem Mac mini – per Docker oder Python.' },
-  { icon: 'fa-wifi', title: 'Verbinden', desc: 'Greife per Browser, Tailscale oder Cloudflare Tunnel zu.' },
-  { icon: 'fa-puzzle-piece', title: 'Anbinden', desc: 'Immich, Nextcloud, Home Assistant, TrueNAS konfigurieren.' },
-  { icon: 'fa-comment', title: 'Loslegen', desc: 'Fragen, Zusammenfassen, Steuern – alles per Chat.' }
-];
-
-const INTEGRATIONS = [
-  { icon: 'fa-home', name: 'Home Assistant' },
-  { icon: 'fa-camera', name: 'Immich' },
-  { icon: 'fa-cloud', name: 'Nextcloud' },
-  { icon: 'fa-database', name: 'TrueNAS' },
-  { icon: 'fa-envelope', name: 'E-Mail' },
-  { icon: 'fa-code', name: 'Python' },
-  { icon: 'fa-docker', name: 'Docker' },
-  { icon: 'fa-robot', name: 'Ollama' },
-  { icon: 'fa-bolt', name: 'Homebridge' },
-  { icon: 'fa-calendar', name: 'CalDAV' },
-  { icon: 'fa-file-alt', name: 'Dateisystem' }
-];
 
 const LANGUAGES = ['de', 'en'];
 
+const FEATURES = [
+  {
+    number: '01', icon: 'fa-comment-dots',
+    title: { de: 'Privater KI-Chat', en: 'Private AI chat' },
+    desc: {
+      de: 'Sprich mit einer KI, die deine freigegebenen Quellen versteht – ohne den Überblick über sensible Daten zu verlieren.',
+      en: 'Talk to an AI that understands the sources you approve—without losing sight of where sensitive data goes.'
+    },
+    detail: { de: 'Kontext statt Copy & Paste', en: 'Context, not copy & paste' }
+  },
+  {
+    number: '02', icon: 'fa-diagram-project',
+    title: { de: 'Wissen über Quellen hinweg', en: 'Knowledge across sources' },
+    desc: {
+      de: 'Dokumente, Fotos, E-Mails und Notizen werden zu einem durchsuchbaren persönlichen Kontext verbunden.',
+      en: 'Documents, photos, email and notes become one searchable layer of personal context.'
+    },
+    detail: { de: 'Antworten mit Herkunft', en: 'Answers with provenance' }
+  },
+  {
+    number: '03', icon: 'fa-list-check',
+    title: { de: 'Aufgaben, die weiterdenken', en: 'Tasks that think ahead' },
+    desc: {
+      de: 'Finde offene Punkte, fasse Wochen zusammen und verbinde Routinen mit deinen vorhandenen Diensten.',
+      en: 'Surface open loops, recap your week and connect routines to the services you already use.'
+    },
+    detail: { de: 'Automationen unter Kontrolle', en: 'Automations under control' }
+  },
+  {
+    number: '04', icon: 'fa-shield-halved',
+    title: { de: 'Erlaubnis vor Aktion', en: 'Permission before action' },
+    desc: {
+      de: 'Du entscheidest, welches Plugin lesen darf und wann eine schreibende Aktion bestätigt werden muss.',
+      en: 'You decide which plugin may read data and when a write action needs explicit confirmation.'
+    },
+    detail: { de: 'Nachvollziehbar & widerrufbar', en: 'Visible and revocable' }
+  }
+];
+
+const INTEGRATIONS = [
+  { icon: 'fa-cloud', type: 'fas', name: 'Nextcloud', desc: { de: 'Dateien, Kalender & Aufgaben', en: 'Files, calendar & tasks' } },
+  { icon: 'fa-images', type: 'fas', name: 'Immich', desc: { de: 'Deine private Fotobibliothek', en: 'Your private photo library' } },
+  { icon: 'fa-house-signal', type: 'fas', name: 'Home Assistant', desc: { de: 'Zuhause verstehen & steuern', en: 'Understand & control your home' } },
+  { icon: 'fa-envelope', type: 'fas', name: 'E-Mail', desc: { de: 'Postfach als Kontext', en: 'Inbox as context' } },
+  { icon: 'fa-spotify', type: 'fab', name: 'Spotify', desc: { de: 'Musik mit einem Satz', en: 'Music in one sentence' } },
+  { icon: 'fa-discord', type: 'fab', name: 'Discord', desc: { de: 'Communities im Blick', en: 'Keep up with communities' } },
+  { icon: 'fa-database', type: 'fas', name: 'TrueNAS', desc: { de: 'Speicher & Dienste', en: 'Storage & services' } },
+  { icon: 'fa-globe', type: 'fas', name: 'Browser', desc: { de: 'Das Web als Werkzeug', en: 'The web as a tool' } }
+];
+
+const ORBIT_NODES = [
+  { key: 'chat', icon: 'fa-comment-dots', label: { de: 'Chat', en: 'Chat' } },
+  { key: 'knowledge', icon: 'fa-book-open', label: { de: 'Wissen', en: 'Knowledge' } },
+  { key: 'tasks', icon: 'fa-list-check', label: { de: 'Aufgaben', en: 'Tasks' } },
+  { key: 'home', icon: 'fa-house', label: { de: 'Zuhause', en: 'Home' } },
+  { key: 'photos', icon: 'fa-images', label: { de: 'Fotos', en: 'Photos' } },
+  { key: 'spotify', icon: 'fa-spotify', type: 'fab', label: { de: 'Spotify', en: 'Spotify' } },
+  { key: 'discord', icon: 'fa-discord', type: 'fab', label: { de: 'Discord', en: 'Discord' } }
+];
+
 export default function LandingPage() {
-  const [langIdx, setLangIdx] = useState(0);
+  const [lang, setLang] = useState('de');
 
   useEffect(() => {
     try {
       const stored = localStorage.getItem('mynd_language');
-      const idx = LANGUAGES.indexOf(stored);
-      if (idx >= 0) setLangIdx(idx);
+      if (LANGUAGES.includes(stored)) setLang(stored);
     } catch {}
   }, []);
 
-  const lang = LANGUAGES[langIdx];
-  const _ = (de, en) => lang === 'de' ? de : en;
+  const text = (copy) => copy[lang];
+  const tr = (de, en) => lang === 'de' ? de : en;
 
-  const toggleLang = () => {
+  const toggleLanguage = () => {
     const next = lang === 'de' ? 'en' : 'de';
-    setLangIdx(LANGUAGES.indexOf(next));
+    setLang(next);
     try { localStorage.setItem('mynd_language', next); } catch {}
   };
 
-  const scrollTo = (id) => {
-    document.getElementById(id)?.scrollIntoView({ behavior: 'smooth' });
-  };
-
   return (
-    <div className="lp">
-      <nav className="lp-nav">
-        <div className="lp-nav-inner">
-          <div className="lp-logo">
-            <span className="lp-logo-icon">◆</span>
-            <span>MYND</span>
-          </div>
-          <div className="lp-nav-links">
-            <button onClick={() => scrollTo('features')}>{_('Features', 'Features')}</button>
-            <button onClick={() => scrollTo('setup')}>{_('Ablauf', 'Setup')}</button>
-            <button onClick={() => scrollTo('integrations')}>{_('Integrationen', 'Integrations')}</button>
-          </div>
-          <div className="lp-nav-right">
-            <button className="lp-lang-toggle" onClick={toggleLang}>
-              {lang === 'de' ? 'EN' : 'DE'}
-            </button>
-            <a href="/login" className="lp-btn lp-btn-primary">{_('Anmelden', 'Login')}</a>
-          </div>
-        </div>
-      </nav>
+    <main className="lp" lang={lang} data-auth-view="public">
+      <a className="lp-skip" href="#main-content">{tr('Zum Inhalt', 'Skip to content')}</a>
 
-      <section className="lp-hero">
-        <div className="lp-hero-content">
-          <h1 className="lp-hero-title">
-            {_('Dein', 'Your')} <em>{_('lokaler KI-Assistent', 'local AI workspace')}</em>
-          </h1>
-          <p className="lp-hero-sub">
-            {_(
-              'KI-Chat, Smart Home und Wissensmanagement in einer lokalen Plattform.',
-              'AI chat, smart home and knowledge management – all local.'
-            )}
-          </p>
-          <div className="lp-hero-actions">
-            <a href="/login" className="lp-btn lp-btn-primary">
-              {_('Jetzt starten', 'Get Started')}
-            </a>
-            <button className="lp-btn lp-btn-secondary" onClick={() => scrollTo('features')}>
-              {_('Mehr erfahren', 'Learn more')}
+      <header className="lp-nav">
+        <nav className="lp-nav-inner" aria-label={tr('Hauptnavigation', 'Main navigation')}>
+          <a className="lp-logo" href="#top" aria-label="MYND Home">
+            <span className="lp-logo-mark" aria-hidden="true" />
+            <span>MYND</span>
+          </a>
+          <div className="lp-nav-links">
+            <a href="#features">{tr('Funktionen', 'Features')}</a>
+            <a href="#integrations">{tr('Integrationen', 'Integrations')}</a>
+            <a href="#privacy">{tr('Privatsphäre', 'Privacy')}</a>
+          </div>
+          <div className="lp-nav-actions">
+            <button className="lp-language" type="button" onClick={toggleLanguage} aria-label={tr('Switch to English', 'Auf Deutsch wechseln')}>
+              <span className={lang === 'de' ? 'active' : ''}>DE</span><i aria-hidden="true" /><span className={lang === 'en' ? 'active' : ''}>EN</span>
             </button>
+            <Link href="/login" className="lp-signin lp-signin-nav" data-testid="landing-login">
+              {tr('Anmelden', 'Sign in')} <i className="fas fa-arrow-right" aria-hidden="true" />
+            </Link>
+          </div>
+        </nav>
+      </header>
+
+      <section className="lp-hero" id="top">
+        <div className="lp-hero-grid" id="main-content">
+          <div className="lp-hero-copy">
+            <p className="lp-eyebrow"><span /> {tr('Lokale Intelligenz. Persönlicher Kontext.', 'Local intelligence. Personal context.')}</p>
+            <h1>{tr('Dein digitales Leben,', 'Your digital life,')} <em>{tr('endlich verbunden.', 'finally connected.')}</em></h1>
+            <p className="lp-hero-lede">
+              {tr(
+                'MYND bringt Chats, Wissen, Aufgaben und dein Zuhause in einen privaten KI-Arbeitsraum – auf deiner Infrastruktur und unter deiner Kontrolle.',
+                'MYND brings chats, knowledge, tasks and your home into one private AI workspace—on your infrastructure and under your control.'
+              )}
+            </p>
+            <div className="lp-hero-actions">
+              <Link href="/login" className="lp-primary-cta">
+                <span>{tr('Bei MYND anmelden', 'Sign in to MYND')}</span>
+                <i className="fas fa-arrow-right" aria-hidden="true" />
+              </Link>
+              <a href="#features" className="lp-text-cta">
+                {tr('Entdecken, was MYND verbindet', 'Explore what MYND connects')}
+                <i className="fas fa-arrow-down" aria-hidden="true" />
+              </a>
+            </div>
+            <p className="lp-hero-note"><i className="fas fa-lock" aria-hidden="true" /> {tr('Deine Daten bleiben dort, wo du sie haben willst.', 'Your data stays where you want it.')}</p>
+          </div>
+
+          <div className="lp-constellation" aria-label={tr('MYND verbindet deine persönlichen Dienste zu einem Kontext.', 'MYND connects your personal services into one context.')}>
+            <div className="lp-orbit lp-orbit-one" aria-hidden="true" />
+            <div className="lp-orbit lp-orbit-two" aria-hidden="true" />
+            <div className="lp-orbit lp-orbit-three" aria-hidden="true" />
+            <div className="lp-core">
+              <span className="lp-core-mark" aria-hidden="true" />
+              <strong>MYND</strong>
+              <small>{tr('Dein Kontext', 'Your context')}</small>
+            </div>
+            {ORBIT_NODES.map((node) => (
+              <div className={`lp-node lp-node-${node.key}`} key={node.key}>
+                <i className={`${node.type || 'fas'} ${node.icon}`} aria-hidden="true" />
+                <span>{text(node.label)}</span>
+              </div>
+            ))}
+            <div className="lp-signal lp-signal-a" aria-hidden="true" />
+            <div className="lp-signal lp-signal-b" aria-hidden="true" />
+            <div className="lp-signal lp-signal-c" aria-hidden="true" />
           </div>
         </div>
       </section>
 
-      <div className="lp-card-section" id="features">
-        <div className="lp-card-section-inner">
-          <div className="lp-card-section-header">
-            <h2>{_('Features', 'Features')}</h2>
-            <p>{_('Lokal, sicher, intelligent.', 'Local, secure, intelligent.')}</p>
-          </div>
-          <div className="lp-card-grid">
-            {FEATURES.map((f, i) => (
-              <div key={i} className="lp-card" style={{ animation: `lpFadeIn 0.4s ease-out ${i * 0.06}s both` }}>
-                <div className="lp-card-icon"><i className={`fas ${f.icon}`} /></div>
-                <h3>{f.title}</h3>
-                <p>{f.desc}</p>
+      <aside className="lp-proof" aria-label={tr('Produktprinzipien', 'Product principles')}>
+        <div className="lp-proof-inner">
+          <p><i className="fas fa-server" aria-hidden="true" /><span><strong>{tr('Local-first', 'Local-first')}</strong>{tr('Auf deiner Infrastruktur', 'On your infrastructure')}</span></p>
+          <p><i className="fas fa-puzzle-piece" aria-hidden="true" /><span><strong>{tr('Erweiterbar', 'Extensible')}</strong>{tr('Plugins für deine Dienste', 'Plugins for your services')}</span></p>
+          <p><i className="fas fa-fingerprint" aria-hidden="true" /><span><strong>{tr('Explizit', 'Explicit')}</strong>{tr('Berechtigungen pro Aktion', 'Permissions per action')}</span></p>
+        </div>
+      </aside>
+
+      <section className="lp-features" id="features">
+        <div className="lp-section-intro">
+          <p className="lp-kicker">{tr('Ein Gedächtnis mit Grenzen', 'A memory with boundaries')}</p>
+          <h2>{tr('Mehr Zusammenhang. Weniger Suchen.', 'More context. Less searching.')}</h2>
+          <p>{tr('MYND macht aus verteilten Informationen einen nutzbaren Kontext – und lässt dich bestimmen, wie weit dieser reicht.', 'MYND turns scattered information into useful context—and lets you decide exactly how far that context reaches.')}</p>
+        </div>
+
+        <div className="lp-feature-list">
+          {FEATURES.map((feature, index) => (
+            <article className={`lp-feature lp-feature-${index + 1}`} key={feature.number}>
+              <div className="lp-feature-index">{feature.number}</div>
+              <div className="lp-feature-icon"><i className={`fas ${feature.icon}`} aria-hidden="true" /></div>
+              <div className="lp-feature-copy">
+                <h3>{text(feature.title)}</h3>
+                <p>{text(feature.desc)}</p>
               </div>
-            ))}
-          </div>
+              <div className="lp-feature-detail"><span />{text(feature.detail)}</div>
+            </article>
+          ))}
         </div>
-      </div>
+      </section>
 
-      <div className="lp-card-section" id="setup">
-        <div className="lp-card-section-inner">
-          <div className="lp-card-section-header">
-            <h2>{_('Setup', 'Setup')}</h2>
-            <p>{_('In Minuten einsatzbereit.', 'Ready in minutes.')}</p>
+      <section className="lp-integrations" id="integrations">
+        <div className="lp-integrations-head">
+          <div>
+            <p className="lp-kicker">{tr('Deine Dienste. Eine Sprache.', 'Your services. One language.')}</p>
+            <h2>{tr('Verbindungen, die du auswählst.', 'Connections you choose.')}</h2>
           </div>
-          <div className="lp-steps">
-            {STEPS.map((s, i) => (
-              <div key={i} className="lp-step">
-                <div className="lp-step-icon"><i className={`fas ${s.icon}`} /></div>
-                <h3>{s.title}</h3>
-                <p>{s.desc}</p>
-              </div>
-            ))}
-          </div>
+          <p>{tr('MYND wächst mit deinem Setup. Aktiviere nur die Werkzeuge, die du wirklich brauchst.', 'MYND grows with your setup. Enable only the tools you actually need.')}</p>
         </div>
-      </div>
-
-      <div className="lp-card-section" id="tech">
-        <div className="lp-card-section-inner">
-          <div className="lp-card-section-header">
-            <h2>{_('Technik', 'Tech')}</h2>
-            <p>{_('Modernste Technologie, maximale Kontrolle.', 'Cutting-edge tech, maximum control.')}</p>
-          </div>
-          <div className="lp-numbers">
-            <div className="lp-number-item">
-              <div className="lp-number-value">76+</div>
-              <div className="lp-number-label">{_('Tools', 'Tools')}</div>
-            </div>
-            <div className="lp-number-item">
-              <div className="lp-number-value">8</div>
-              <div className="lp-number-label">{_('Dienste', 'Services')}</div>
-            </div>
-            <div className="lp-number-item">
-              <div className="lp-number-value">306k</div>
-              <div className="lp-number-label">{_('Fotos', 'Photos')}</div>
-            </div>
-            <div className="lp-number-item">
-              <div className="lp-number-value">24/7</div>
-              <div className="lp-number-label">{_('Verfügbar', 'Available')}</div>
-            </div>
-          </div>
+        <div className="lp-integration-rail">
+          {INTEGRATIONS.map((integration) => (
+            <article className="lp-integration" key={integration.name}>
+              <i className={`${integration.type} ${integration.icon}`} aria-hidden="true" />
+              <div><h3>{integration.name}</h3><p>{text(integration.desc)}</p></div>
+            </article>
+          ))}
         </div>
-      </div>
+      </section>
 
-      <div className="lp-card-section" id="integrations">
-        <div className="lp-card-section-inner">
-          <div className="lp-card-section-header">
-            <h2>{_('Integrationen', 'Integrations')}</h2>
-            <p>{_('Alle Dienste auf einen Blick.', 'All services at a glance.')}</p>
-          </div>
-          <div className="lp-integrations">
-            {INTEGRATIONS.map((int, i) => (
-              <div key={i} className="lp-integration-item">
-                <i className={`fas ${int.icon}`} />
-                <span>{int.name}</span>
-              </div>
-            ))}
-          </div>
+      <section className="lp-privacy" id="privacy">
+        <div className="lp-privacy-visual" aria-hidden="true">
+          <div className="lp-vault-ring lp-vault-ring-outer" />
+          <div className="lp-vault-ring lp-vault-ring-inner" />
+          <div className="lp-vault-core"><i className="fas fa-fingerprint" /></div>
+          <span className="lp-vault-label lp-vault-label-one">LOCAL</span>
+          <span className="lp-vault-label lp-vault-label-two">READ</span>
+          <span className="lp-vault-label lp-vault-label-three">CONFIRM</span>
         </div>
-      </div>
+        <div className="lp-privacy-copy">
+          <p className="lp-kicker">{tr('Privat by design', 'Private by design')}</p>
+          <h2>{tr('Dein Kontext gehört nicht in eine Blackbox.', 'Your context does not belong in a black box.')}</h2>
+          <p>{tr('MYND ist für den Betrieb auf deiner eigenen Infrastruktur gedacht. Datenquellen werden bewusst verbunden, Rechte bleiben sichtbar und sensible Aktionen verlangen deine Freigabe.', 'MYND is designed to run on your own infrastructure. Sources are connected deliberately, permissions stay visible and sensitive actions require your approval.')}</p>
+          <ul>
+            <li><i className="fas fa-check" aria-hidden="true" />{tr('Lokale und selbst gehostete Modelle einbinden', 'Connect local and self-hosted models')}</li>
+            <li><i className="fas fa-check" aria-hidden="true" />{tr('Plugins einzeln aktivieren oder widerrufen', 'Enable or revoke plugins individually')}</li>
+            <li><i className="fas fa-check" aria-hidden="true" />{tr('Schreibende Aktionen bewusst bestätigen', 'Explicitly confirm write actions')}</li>
+          </ul>
+        </div>
+      </section>
 
-      <div className="lp-cta">
-        <h2>{_('Bereit für deinen KI-Assistenten?', 'Ready for your AI workspace?')}</h2>
-        <p>{_('Starte jetzt.', 'Start now.')}</p>
-        <a href="/login" className="lp-btn lp-btn-primary">{_('Jetzt starten', 'Get Started')}</a>
-      </div>
+      <section className="lp-final">
+        <p className="lp-kicker">{tr('Bereit, den Kontext zusammenzubringen?', 'Ready to bring the context together?')}</p>
+        <h2>{tr('Ein Arbeitsraum. Deine Regeln.', 'One workspace. Your rules.')}</h2>
+        <Link href="/login" className="lp-primary-cta lp-final-cta">
+          <span>{tr('Anmeldung öffnen', 'Open sign in')}</span><i className="fas fa-arrow-right" aria-hidden="true" />
+        </Link>
+      </section>
 
       <footer className="lp-footer">
-        <div className="lp-footer-inner">
-          <div className="lp-logo" style={{ justifyContent: 'center', marginBottom: '0.35rem' }}>
-            <span className="lp-logo-icon">◆</span>
-            <span>MYND</span>
-          </div>
-          <p>{_('Lokal. Privat. Dein KI-Assistent.', 'Local. Private. Your AI Workspace.')}</p>
-        </div>
+        <a className="lp-logo" href="#top"><span className="lp-logo-mark" aria-hidden="true" /><span>MYND</span></a>
+        <p>© {new Date().getFullYear()} MYND · {tr('Lokal. Privat. Verbunden.', 'Local. Private. Connected.')}</p>
+        <a href="#privacy">{tr('Privatsphäre', 'Privacy')}</a>
       </footer>
-    </div>
+    </main>
   );
 }

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -171,6 +171,17 @@ class TestSecurityAPI:
         resp = client.get("/api/security/status")
         assert resp.status_code == 200
 
+    def test_api_allows_any_browser_origin_without_csp(self, client, monkeypatch):
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "*")
+        response = client.get(
+            "/api/capabilities",
+            headers={"Origin": "https://any-domain.example"},
+        )
+
+        assert response.status_code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "https://any-domain.example"
+        assert "Content-Security-Policy" not in response.headers
+
     def test_sensitive_routes_require_authentication(self, client):
         response = client.get("/api/vault/entries", headers={"Authorization": ""})
         assert response.status_code == 401

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -27,6 +27,12 @@ def test_application_entry_loads_without_browser_errors():
 
         response = page.goto(f'{base_url}/login', wait_until='networkidle')
 
+        # Python's static CI server prefers the generated ``login/`` directory
+        # over Next's sibling ``login.html`` export. Follow the exported page
+        # explicitly when that server returns a directory listing.
+        if page.title().startswith('Directory listing for /login'):
+            response = page.goto(f'{base_url}/login.html', wait_until='networkidle')
+
         assert response is not None and response.ok
         if page.title().strip() == 'MYND Setup | MYND':
             expect(page.get_by_role('heading', name='Start wählen')).to_be_visible()

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -19,9 +19,13 @@ def test_application_entry_loads_without_browser_errors():
         browser = playwright.chromium.launch(headless=True)
         page = browser.new_page()
         page.on('pageerror', lambda error: page_errors.append(str(error)))
+        page.route(
+            '**/api/setup/status',
+            lambda route: route.fulfill(json={'success': True, 'needs_setup': False}),
+        )
         page.add_init_script("localStorage.setItem('mynd_language', 'en')")
 
-        response = page.goto(f'{base_url}/login.html', wait_until='networkidle')
+        response = page.goto(f'{base_url}/login', wait_until='networkidle')
 
         assert response is not None and response.ok
         if page.title().strip() == 'MYND Setup | MYND':
@@ -35,13 +39,58 @@ def test_application_entry_loads_without_browser_errors():
         browser.close()
 
 
+def test_unauthenticated_root_stays_public_and_offers_sign_in():
+    base_url = os.getenv('MYND_BROWSER_BASE_URL', 'http://127.0.0.1:3000').rstrip('/')
+    page_errors = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = browser.new_context(service_workers='block')
+        context.clear_cookies()
+        page = context.new_page()
+        page.on('pageerror', lambda error: page_errors.append(str(error)))
+        def fulfill_unauthenticated_api(route):
+            if route.request.url.endswith('/api/setup/status'):
+                payload = {'success': True, 'needs_setup': False}
+            elif route.request.url.endswith('/api/auth/me'):
+                payload = {'authenticated': False, 'user': None}
+            else:
+                payload = {'success': True}
+            route.fulfill(json=payload)
+
+        page.route('**/api/**', fulfill_unauthenticated_api)
+        page.add_init_script(
+            """
+            localStorage.clear();
+            sessionStorage.clear();
+            localStorage.setItem('mynd_token_v1', 'deliberately-invalid-smoke-token');
+            localStorage.removeItem('mynd_language');
+            """
+        )
+
+        response = page.goto(f'{base_url}/', wait_until='networkidle')
+
+        assert response is not None and response.ok
+        expect(page).to_have_url(f'{base_url}/')
+        public_landing = page.locator('.lp[data-auth-view="public"]')
+        expect(public_landing).to_be_visible()
+        sign_in = page.get_by_test_id('landing-login')
+        expect(sign_in).to_have_count(1)
+        expect(sign_in).to_have_attribute('href', '/login')
+        expect(page.locator('[data-auth-view="workspace"]')).to_have_count(0)
+        assert page_errors == []
+        browser.close()
+
+
 def test_authenticated_user_can_create_new_chats_from_empty_state():
     base_url = os.getenv('MYND_BROWSER_BASE_URL', 'http://127.0.0.1:3000').rstrip('/')
     page_errors = []
 
     with sync_playwright() as playwright:
         browser = playwright.chromium.launch(headless=True)
-        page = browser.new_page()
+        context = browser.new_context(service_workers='block')
+        context.clear_cookies()
+        page = context.new_page()
         page.on('pageerror', lambda error: page_errors.append(str(error)))
         def fulfill_authenticated_api(route):
             if route.request.url.endswith('/api/setup/status'):
@@ -68,6 +117,8 @@ def test_authenticated_user_can_create_new_chats_from_empty_state():
         response = page.goto(f'{base_url}/', wait_until='networkidle')
 
         assert response is not None and response.ok
+        expect(page.locator('[data-auth-view="workspace"]')).to_be_visible()
+        expect(page.locator('[data-auth-view="public"]')).to_have_count(0)
         new_chat_button = page.locator('.primary-nav .nav-item').first
         expect(new_chat_button).to_be_visible()
         expect(page.locator('.landing')).to_be_visible()


### PR DESCRIPTION
## Summary
- show a modern public landing page at `/` for signed-out visitors
- remove CSP headers and the frontend CSP meta tag
- allow API access from arbitrary browser origins
- keep setup and authenticated workspace routing intact

## Root cause
The production HTML contained a restrictive CSP meta tag with an invalid/empty source expression. It blocked Next.js assets, Cloudflare Insights/Zaraz, fonts, and styles on the custom domain.

## Verification
- `make check` (110 passed, 4 skipped; lint, typecheck, security, audits, production build)
- `MYND_BROWSER_BASE_URL=http://localhost:3000 uv run pytest tests/test_browser_smoke.py -q` (3 passed)
- arbitrary-Origin API response verified without a CSP response header