### PR TITLE
fix: tool confirmation, admin role, guide overhaul, plugin manager

### DIFF
--- a/app/agent_loop.py
+++ b/app/agent_loop.py
@@ -13,6 +13,7 @@ from app.state import _PENDING_TOOL_CONFIRMS, _PRIVILEGED_TOOL_NAMES, _PRIVILEGE
 from core.llm import chat_with_tools, chat_with_tools_stream
 from core.plugin_base import get_all_tools
 from core.tools import CORE_MAP, CORE_TOOLS, execute_ssh, http_request, safe_http_request, think, vault_set
+from app.helpers import load_security_mode
 from core.vault import load_vault
 
 plugins_loaded = False
@@ -36,6 +37,9 @@ _CONFIRMATION_REQUIRED_TOOLS = frozenset({
 
 
 def _tool_requires_confirmation(name, args):
+    mode = load_security_mode().get('mode', 'standard')
+    if mode == 'admin':
+        return False
     if name in _CONFIRMATION_REQUIRED_TOOLS:
         return True
     if name in {'http_request', 'nextcloud_request', 'immich_api_request', 'truenas_api_request'}:
@@ -65,7 +69,9 @@ def load_plugins():
     _load_plugins()
     PLUGIN_TOOLS, PLUGIN_TOOL_MAP = _get_all_tools()
     AGENT_TOOLS = [*CORE_TOOLS, *PLUGIN_TOOLS]
-    WEB_TOOL_MAP = {**CORE_MAP, **PLUGIN_TOOL_MAP, 'prompt_user': web_prompt_user}
+    new_map = {**CORE_MAP, **PLUGIN_TOOL_MAP, 'prompt_user': web_prompt_user}
+    WEB_TOOL_MAP.clear()
+    WEB_TOOL_MAP.update(new_map)
     plugins_loaded = True
 
 

--- a/app/agent_loop.py
+++ b/app/agent_loop.py
@@ -8,12 +8,12 @@ import core.tools as _ct
 
 # Plugin references
 from app.config import DATA_DIR, GENERATED_DIR, VAULT_FILE, _app_lock, logger
+from app.helpers import load_security_mode
 from app.session_store import agent_sessions
 from app.state import _PENDING_TOOL_CONFIRMS, _PRIVILEGED_TOOL_NAMES, _PRIVILEGED_TOOL_PREFIXES, _audit_log
 from core.llm import chat_with_tools, chat_with_tools_stream
 from core.plugin_base import get_all_tools
 from core.tools import CORE_MAP, CORE_TOOLS, execute_ssh, http_request, safe_http_request, think, vault_set
-from app.helpers import load_security_mode
 from core.vault import load_vault
 
 plugins_loaded = False

--- a/app/routes.py
+++ b/app/routes.py
@@ -263,7 +263,7 @@ def admin_users_list():
     from app.state import AUTH_USERS
     return jsonify({
         'success': True,
-        'users': [{'username': u, 'name': d.get('name', '')} for u, d in AUTH_USERS.items()]
+        'users': [{'username': u, 'name': d.get('name', ''), 'role': d.get('role', 'user')} for u, d in AUTH_USERS.items()]
     })
 
 @app.route('/api/admin/users/create', methods=['POST'])
@@ -278,12 +278,15 @@ def admin_users_create():
         return jsonify({'success': False, 'error': 'Username and password required'}), 400
     if username in AUTH_USERS:
         return jsonify({'success': False, 'error': 'User already exists'}), 409
+    role = data.get('role', 'user')
+    if role not in ('user', 'admin'):
+        return jsonify({'success': False, 'error': 'Role must be user or admin'}), 400
     AUTH_USERS[username] = {
         'password_hash': generate_password_hash(password),
-        'name': name or username, 'role': 'user',
+        'name': name or username, 'role': role,
     }
     AUTH_FILE.write_text(json.dumps(AUTH_USERS, indent=2))
-    return jsonify({'success': True, 'user': {'username': username, 'name': name or username}})
+    return jsonify({'success': True, 'user': {'username': username, 'name': name or username, 'role': role}})
 
 @app.route('/api/admin/users/delete', methods=['POST'])
 @require_admin

--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -880,15 +880,16 @@ export default function HomePage() {
       )}
       {pendingToolConfirm && (
         <div className="modal-overlay" onClick={() => setPendingToolConfirm(null)}>
-          <div className="modal-card" onClick={(e) => e.stopPropagation()} style={{maxWidth: '480px'}}>
+          <div className="modal-card" onClick={(e) => e.stopPropagation()} style={{maxWidth:'420px'}}>
             <div className="modal-head">
-              <strong>{tr('Tool-Best\u00e4tigung', 'Tool Confirmation')}</strong>
+              <strong><i className="fas fa-shield-halved" style={{color:'var(--accent)',marginRight:8}}></i>{tr('Tool-Best\u00e4tigung', 'Tool Confirmation')}</strong>
               <button className="modal-x" onClick={() => setPendingToolConfirm(null)}>&times;</button>
             </div>
-            <div className="modal-body" style={{padding: '20px'}}>
-              <p style={{marginBottom: '12px', color: '#e8a040'}}><i className="fas fa-shield-halved"></i> <strong>{pendingToolConfirm.tool}</strong>: {pendingToolConfirm.description}</p>
-              <p style={{fontSize: '0.9em', color: '#999', marginBottom: '20px'}}>{tr('M\u00f6chtest du die Ausf\u00fchrung dieses Tools erlauben?', 'Do you want to allow executing this tool?')}</p>
-              <div style={{display: 'flex', gap: '10px', justifyContent: 'flex-end'}}>
+            <div className="modal-body" style={{padding:'12px 20px 20px'}}>
+              <div className="tool-confirm-tool">{pendingToolConfirm.tool}</div>
+              <p className="tool-confirm-desc">{pendingToolConfirm.description}</p>
+              <p className="tool-confirm-question">{tr('M\u00f6chtest du die Ausf\u00fchrung dieses Tools erlauben?', 'Do you want to allow executing this tool?')}</p>
+              <div className="tool-confirm-actions">
                 <button className="btn btn-secondary" onClick={async () => {
                   const confirmationId = pendingToolConfirm.confirmationId;
                   setPendingToolConfirm(null);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1139,6 +1139,22 @@ body {
   align-items: center;
   justify-content: center;
 }
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: modal-fadein 0.15s ease;
+}
+@keyframes modal-fadein {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
 .modal-card {
   background: var(--panel);
   border: 1px solid var(--line);
@@ -1148,6 +1164,7 @@ body {
   max-height: 76vh;
   display: flex;
   flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0,0,0,0.35);
 }
 .modal-head {
   display: flex;
@@ -1181,6 +1198,31 @@ body {
   flex: 1;
   overflow-y: auto;
   padding: 0.4rem 0.4rem 0.6rem;
+}
+.tool-confirm-tool {
+  display: inline-block;
+  padding: 0.2rem 0.7rem;
+  margin-bottom: 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  font: 600 0.85rem/1.6 var(--font-ibm-plex-mono, monospace);
+}
+.tool-confirm-desc {
+  margin: 0 0 12px;
+  color: var(--body);
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+.tool-confirm-question {
+  margin: 0 0 16px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+.tool-confirm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 .modal-empty {
   display: flex;

--- a/frontend/app/guide/page.js
+++ b/frontend/app/guide/page.js
@@ -5,8 +5,10 @@ import Link from 'next/link';
 import './guide.css';
 
 const SECTIONS = [
+  { id: 'architecture', icon: 'fa-sitemap', label_de: 'Architektur', label_en: 'Architecture' },
   { id: 'getting-started', icon: 'fa-rocket', label_de: 'Erste Schritte', label_en: 'Getting Started' },
-  { id: 'ai-setup', icon: 'fa-brain', label_de: 'KI einrichten', label_en: 'AI Setup' },
+  { id: 'ai-setup', icon: 'fa-brain', label_de: 'KI-Modelle', label_en: 'AI Models' },
+  { id: 'security', icon: 'fa-shield-halved', label_de: 'Sicherheit & Modi', label_en: 'Security & Modes' },
   { id: 'nextcloud', icon: 'fa-cloud', label_de: 'Nextcloud', label_en: 'Nextcloud' },
   { id: 'immich', icon: 'fa-images', label_de: 'Immich', label_en: 'Immich' },
   { id: 'homeassistant', icon: 'fa-house-signal', label_de: 'Home Assistant', label_en: 'Home Assistant' },
@@ -18,262 +20,320 @@ const SECTIONS = [
 ];
 
 const GUIDE = {
-  'getting-started': {
-    de: {
-      title: 'Erste Schritte',
-      intro: 'MYND ist deine lokale Personal-AI-Plattform. Stelle Fragen zu deinen Dateien, Geräten und Diensten — alles läuft auf deiner eigenen Infrastruktur.',
+  'architecture': {
+    en: {
+      title: 'Architecture',
+      intro: 'MYND is a full-stack personal AI platform. Understanding the architecture helps you set it up correctly and get the most out of it.',
       steps: [
-        { h: '1. Server starten', p: 'Starte den MYND-Backend-Server mit \'python app.py\' im Hauptverzeichnis. Der Server läuft standardmäßig auf Port 5001.' },
-        { h: '2. Frontend öffnen', p: 'Öffne das Frontend im Browser. Lokal erreichst du es über http://localhost:3000. Im Produktivbetrieb konfiguriere einen Reverse Proxy (z.B. nginx).' },
-        { h: '3. Account erstellen', p: 'Klicke auf "Anmelden" und dann auf "Account erstellen". Lege Benutzernamen und Passwort fest.' },
-        { h: '4. KI-Modell wählen', p: 'Nach dem Login wähle im Dashboard dein KI-Modell aus. MYND unterstützt alle Ollama-Modelle sowie OpenAI-kompatible APIs.' },
-        { h: '5. Integrationen aktivieren', p: 'Gehe in die Einstellungen und verbinde die gewünschten Dienste (Nextcloud, Immich, Home Assistant etc.).' },
+        { h: 'Overview', p: 'MYND consists of three main layers: a Python Flask backend (API server on port 5001), a Next.js frontend (web UI on port 3000), and a local AI model provider (Ollama or OpenAI-compatible API). All three can run on the same machine or be distributed across your network.' },
+        { h: 'Backend (Flask)', p: 'The backend at `app/routes.py` handles all API requests: authentication, AI model communication, plugin management, file storage, vault/credentials, and the agent loop that orchestrates multi-tool AI reasoning. Plugins in `data/plugins/` extend the backend with 25+ tools across 11 integrations.' },
+        { h: 'Frontend (Next.js)', p: 'The React-based UI at `frontend/` provides the chat interface, settings panels, plugin manager, and landing/marketing pages. It communicates with the backend via REST API calls and server-sent events (SSE) for real-time streaming of AI responses.' },
+        { h: 'AI Agent Loop', p: 'When you ask a question, MYND: (1) sends your prompt + available tool definitions to the AI model, (2) the model decides which tools to call and with what arguments, (3) MYND executes each tool and feeds results back to the model, (4) the model produces the final answer. This loop runs up to 100 rounds per query.' },
+        { h: 'Plugin System', p: 'Each integration (Nextcloud, Immich, etc.) is a self-contained plugin in `data/plugins/`. Plugins register tools with OpenAI-compatible function schemas. The system auto-discovers installed plugins at startup. You can write custom plugins in Python — see the Developers page.', tip: 'The system plugin (`system.py`) provides OS-level tools like timers, weather, web search, and disk monitoring — always available, no configuration needed.' },
       ],
     },
+    de: {
+      title: 'Architektur',
+      intro: 'MYND ist eine Full-Stack Personal-AI-Plattform. Das Verständnis der Architektur hilft bei der Einrichtung und optimalen Nutzung.',
+      steps: [
+        { h: 'Überblick', p: 'MYND besteht aus drei Hauptschichten: Einem Python Flask Backend (API-Server auf Port 5001), einem Next.js Frontend (Web-UI auf Port 3000) und einem lokalen KI-Modellanbieter (Ollama oder OpenAI-kompatibel). Alle drei können auf demselben Rechner oder verteilt laufen.' },
+        { h: 'Backend (Flask)', p: 'Das Backend in `app/routes.py` verarbeitet alle API-Anfragen: Authentifizierung, KI-Modell-Kommunikation, Plugin-Verwaltung, Dateispeicher, Tresor/Zugangsdaten und die Agenten-Schleife, die mehrstufige KI-Argumentation orchestriert. Plugins in `data/plugins/` erweitern das Backend um 25+ Tools in 11 Integrationen.' },
+        { h: 'Frontend (Next.js)', p: 'Die React-basierte UI in `frontend/` bietet die Chat-Oberfläche, Einstellungen, Plugin-Manager und Marketing-Seiten. Sie kommuniziert mit dem Backend über REST-API-Aufrufe und Server-Sent-Events (SSE) für Echtzeit-Streaming von KI-Antworten.' },
+        { h: 'KI-Agenten-Schleife', p: 'Wenn du eine Frage stellst, führt MYND folgende Schritte aus: (1) Prompt + verfügbare Tool-Definitionen an das KI-Modell senden, (2) das Modell entscheidet, welche Tools aufgerufen werden, (3) MYND führt jedes Tool aus und gibt die Ergebnisse zurück, (4) das Modell erzeugt die endgültige Antwort. Bis zu 100 Runden pro Anfrage.' },
+        { h: 'Plugin-System', p: 'Jede Integration ist ein eigenständiges Plugin in `data/plugins/`. Plugins registrieren Tools mit OpenAI-kompatiblen Funktionsschemata. Das System erkennt installierte Plugins automatisch beim Start. Du kannst eigene Plugins in Python schreiben — siehe Entwickler-Seite.', tip: 'Das System-Plugin (`system.py`) stellt Betriebssystem-Tools wie Timer, Wetter, Websuche und Festplatten-Überwachung bereit — immer verfügbar, keine Konfiguration nötig.' },
+      ],
+    },
+  },
+  'getting-started': {
     en: {
       title: 'Getting Started',
-      intro: 'MYND is your local personal AI platform. Ask questions about your files, devices and services — everything runs on your own infrastructure.',
+      intro: 'Get MYND up and running on your own infrastructure in minutes. All steps work on Linux, macOS, and Windows.',
       steps: [
-        { h: '1. Start the server', p: 'Run \'python app.py\' in the root directory. The backend server starts on port 5001 by default.' },
-        { h: '2. Open the frontend', p: 'Open the frontend in your browser. Locally it\'s at http://localhost:3000. For production, configure a reverse proxy (e.g. nginx).' },
-        { h: '3. Create an account', p: 'Click "Sign in" then "Create account". Choose a username and password.' },
-        { h: '4. Select an AI model', p: 'After login, select your AI model in the dashboard. MYND supports all Ollama models and OpenAI-compatible APIs.' },
-        { h: '5. Enable integrations', p: 'Go to Settings and connect the services you use (Nextcloud, Immich, Home Assistant, etc.).' },
+        { h: '1. Check system requirements', p: 'Python 3.10+, Node.js 18+, 4 GB RAM minimum (8+ GB recommended), 20+ GB free disk space. For local AI models, you need additional RAM: ~4 GB for small models (Phi, TinyLlama), ~8 GB for medium models (Llama 3.2, Mistral), ~16 GB for large models (Qwen 2.5, Llama 3.1).' },
+        { h: '2. Clone and install backend', p: 'Run these commands:\n\n```\ngit clone https://github.com/SchBenedikt/mynd.git\ncd mynd\npython -m venv .venv\nsource .venv/bin/activate  # Windows: .venv\\Scripts\\activate\npip install -r requirements.txt\n```\n\nThe backend dependencies include Flask, NumPy, requests, and Werkzeug — all standard Python libraries for web servers and data processing.' },
+        { h: '3. Start the backend', p: 'Run `python app.py` from the project root. Expected output: `Running on http://0.0.0.0:5001`. The first run creates a `config.yaml` automatically. The backend is now ready to receive API requests.', tip: 'Keep this terminal open. For production, use a process manager like supervisord or systemd.' },
+        { h: '4. Start the frontend', p: 'Open a second terminal, navigate to `frontend/`, and run:\n\n```\nnpm install\nnpm run dev\n```\n\nThe UI is available at http://localhost:3000. For production: `npm run build && npm start`. The dev mode supports hot-reload for development.' },
+        { h: '5. Set up AI and create account', p: 'Open http://localhost:3000, click "Sign in" → "Create account". After login, go to Settings → AI and configure your model provider (Ollama or OpenAI-compatible). Then go to Settings → Integrations to connect your services.' },
+      ],
+    },
+    de: {
+      title: 'Erste Schritte',
+      intro: 'MYND in wenigen Minuten auf deiner eigenen Infrastruktur einrichten.',
+      steps: [
+        { h: '1. Systemvoraussetzungen prüfen', p: 'Python 3.10+, Node.js 18+, mindestens 4 GB RAM (8+ GB empfohlen), 20+ GB freier Speicher. Für lokale KI-Modelle zusätzlicher RAM: ~4 GB für kleine Modelle (Phi, TinyLlama), ~8 GB für mittlere (Llama 3.2, Mistral), ~16 GB für große (Qwen 2.5, Llama 3.1).' },
+        { h: '2. Repository klonen und Backend installieren', p: 'Führe diese Befehle aus:\n\n```\ngit clone https://github.com/SchBenedikt/mynd.git\ncd mynd\npython -m venv .venv\nsource .venv/bin/activate\npip install -r requirements.txt\n```' },
+        { h: '3. Backend starten', p: 'Führe `python app.py` aus. Erwartete Ausgabe: `Running on http://0.0.0.0:5001`. Beim ersten Start wird automatisch eine `config.yaml` erstellt.', tip: 'Dieses Terminal geöffnet lassen. Für Produktivbetrieb einen Prozess-Manager wie systemd verwenden.' },
+        { h: '4. Frontend installieren und starten', p: 'Öffne ein zweites Terminal, wechsle in `frontend/` und führe aus:\n\n```\nnpm install\nnpm run dev\n```\n\nDie UI ist unter http://localhost:3000 erreichbar.' },
+        { h: '5. KI einrichten und Account erstellen', p: 'Öffne http://localhost:3000, klicke "Sign in" → "Create account". Gehe zu Settings → AI und konfiguriere den Modellanbieter. Danach unter Settings → Integrations die gewünschten Dienste verbinden.' },
       ],
     },
   },
   'ai-setup': {
-    de: {
-      title: 'KI einrichten',
-      intro: 'MYND benötigt ein laufendes Ollama oder einen OpenAI-kompatiblen Anbieter.',
+    en: {
+      title: 'AI Models',
+      intro: 'MYND works with any Ollama model or OpenAI-compatible API. Choosing the right model depends on your hardware and use case. Here is everything you need to know.',
       steps: [
-        { h: 'Ollama installieren', p: 'Lade Ollama von https://ollama.com herunter und installiere es. Starte es mit \'ollama serve\'.' },
-        { h: 'Modell pullen', p: 'Lade ein Modell herunter, z.B. \'ollama pull llama3.2\' oder \'ollama pull mistral\'. Für Werkzeug-Nutzung empfehlen wir llama3.2 oder qwen2.5.' },
-        { h: 'In MYND verbinden', p: 'Gehe in den Einstellungen auf "KI". Trage die Ollama-URL ein (meist http://127.0.0.1:11434) und wähle dein Modell aus.' },
-        { h: 'OpenAI-kompatible APIs', p: 'Du kannst auch jeden OpenAI-kompatiblen Anbieter nutzen (z.B. OpenAI, Groq, Together). Wähle "OpenAI" als Provider und trage Base-URL und API-Key ein.' },
+        { h: '1. Install Ollama (recommended)', p: 'Ollama runs AI models locally on your hardware. Install it:\n\n- **Linux**: `curl -fsSL https://ollama.com/install.sh | sh`\n- **macOS**: Download from https://ollama.com\n- **Windows**: Download from https://ollama.com\n\nAfter installation, Ollama runs as a background service on port 11434. Verify with `curl http://127.0.0.1:11434/api/tags`.' },
+        { h: '2. Choose and pull a model', p: 'Your choice depends on your hardware and needs:\n\n**Hardware** | **Recommended Model** | **RAM** | **Tool Support**\n---|---|---|---\n8 GB RAM | `phi` (2.7 GB) | ~4 GB | Basic\n8 GB RAM | `tinyllama` (0.6 GB) | ~2 GB | No\n16 GB RAM | `llama3.2` (4.7 GB) | ~8 GB | Yes\n16 GB RAM | `mistral` (4.1 GB) | ~7 GB | Yes\n32 GB RAM | `qwen2.5` (4.9 GB) | ~9 GB | Excellent\n32 GB RAM | `llama3.1` (6.4 GB) | ~12 GB | Yes\n\nPull a model: `ollama pull llama3.2`', tip: 'For the best tool-use experience (required for integrations), choose a model with "Yes" or "Excellent" tool support. Models like `phi`, `gemma`, and `tinyllama` do NOT support tool calling.' },
+        { h: '3. Connect MYND to Ollama', p: 'Go to Settings → AI. Select "Ollama" as the provider. Enter `http://127.0.0.1:11434` (or your Ollama host). Click "Fetch Models" and select your downloaded model from the dropdown. Save the config.' },
+        { h: '4. OpenAI-compatible providers', p: 'MYND works with any OpenAI-compatible API. Supported providers include:\n\n- **OpenAI**: `https://api.openai.com/v1` (models: gpt-4o, gpt-4o-mini, o3-mini)\n- **Groq**: `https://api.groq.com/openai/v1` (models: llama-3.3-70b, mixtral-8x7b)\n- **Together**: `https://api.together.xyz/v1` (models: llama-3.3-70b, qwen-2.5-72b)\n- **Anthropic**: `https://api.anthropic.com/v1` (models: claude-3.5-sonnet)\n- **Google Gemini**: Via OpenAI-compatible proxy\n\nSelect "OpenAI Compatible" in Settings → AI, enter the Base URL and API key.', tip: 'Cloud models (OpenAI, Groq) are faster and more capable than local models but cost per request. Local models are free and private.' },
+        { h: '5. Test and verify', p: 'In Settings → AI, use "Test Connection" to verify the provider works. Use "Check Tool Support" to see which models support tool calling. A model without tool support can still answer questions but cannot access your integrations (Nextcloud, Immich, etc.).', tip: 'If a model fails tool support but you believe it should work, check your Ollama version (needs 0.3.0+ for tool calling).' },
       ],
     },
-    en: {
-      title: 'AI Setup',
-      intro: 'MYND requires a running Ollama instance or an OpenAI-compatible provider.',
+    de: {
+      title: 'KI-Modelle',
+      intro: 'MYND funktioniert mit allen Ollama-Modellen und OpenAI-kompatiblen APIs. Die Wahl des richtigen Modells hängt von deiner Hardware und deinem Einsatzzweck ab.',
       steps: [
-        { h: 'Install Ollama', p: 'Download Ollama from https://ollama.com and install it. Run \'ollama serve\' to start.' },
-        { h: 'Pull a model', p: 'Download a model, e.g. \'ollama pull llama3.2\' or \'ollama pull mistral\'. For tool use, we recommend llama3.2 or qwen2.5.' },
-        { h: 'Connect in MYND', p: 'Go to Settings → AI. Enter the Ollama URL (usually http://127.0.0.1:11434) and select your model.' },
-        { h: 'OpenAI-compatible APIs', p: 'You can also use any OpenAI-compatible provider (e.g. OpenAI, Groq, Together). Select "OpenAI" as provider and enter Base URL and API key.' },
+        { h: '1. Ollama installieren (empfohlen)', p: 'Ollama führt KI-Modelle lokal auf deiner Hardware aus. Installation:\n\n- **Linux**: `curl -fsSL https://ollama.com/install.sh | sh`\n- **macOS/Windows**: Download von https://ollama.com\n\nOllama läuft als Hintergrunddienst auf Port 11434. Prüfe mit `curl http://127.0.0.1:11434/api/tags`.' },
+        { h: '2. Modell auswählen und pullen', p: 'Die Wahl hängt von Hardware und Anforderungen ab:\n\n**Hardware** | **Empfohlenes Modell** | **RAM** | **Tool-Support**\n---|---|---|---\n8 GB RAM | `phi` (2.7 GB) | ~4 GB | Basis\n8 GB RAM | `tinyllama` (0.6 GB) | ~2 GB | Nein\n16 GB RAM | `llama3.2` (4.7 GB) | ~8 GB | Ja\n16 GB RAM | `mistral` (4.1 GB) | ~7 GB | Ja\n32 GB RAM | `qwen2.5` (4.9 GB) | ~9 GB | Hervorragend\n32 GB RAM | `llama3.1` (6.4 GB) | ~12 GB | Ja\n\nModell pullen: `ollama pull llama3.2`', tip: 'Für die Nutzung von Integrationen (Nextcloud, Immich etc.) ist Tool-Support erforderlich. Modelle wie `phi`, `gemma` und `tinyllama` unterstützen keine Tools.' },
+        { h: '3. MYND mit Ollama verbinden', p: 'Gehe zu Settings → AI. Wähle "Ollama" als Anbieter. Trage `http://127.0.0.1:11434` ein. Klicke "Fetch Models" und wähle dein Modell aus. Speichern.' },
+        { h: '4. OpenAI-kompatible Anbieter', p: 'MYND funktioniert mit allen OpenAI-kompatiblen APIs:\n\n- **OpenAI**: `https://api.openai.com/v1` (gpt-4o, gpt-4o-mini)\n- **Groq**: `https://api.groq.com/openai/v1` (llama-3.3-70b)\n- **Together**: `https://api.together.xyz/v1`\n\nWähle "OpenAI Compatible" in Settings → AI, trage Base-URL und API-Key ein.', tip: 'Cloud-Modelle sind schneller und leistungsfähiger als lokale, kosten aber pro Anfrage. Lokale Modelle sind kostenlos und privat.' },
+        { h: '5. Testen und prüfen', p: 'Nutze "Test Connection" in Settings → AI, um die Verbindung zu prüfen. "Check Tool Support" zeigt, welche Modelle Tool-Aufrufe unterstützen. Ein Modell ohne Tool-Support kann keine Integrationen nutzen.', tip: 'Ollama benötigt Version 0.3.0+ für Tool-Unterstützung.' },
+      ],
+    },
+  },
+  'security': {
+    en: {
+      title: 'Security & Modes',
+      intro: 'MYND offers multiple security layers and operating modes. Understanding these lets you balance convenience and safety.',
+      steps: [
+        { h: '1. Security Modes', p: 'Settings → AI → Security Mode controls which tools the AI can access:\n\n- **Restricted**: Only document search and memory. No external tools. Safest for untrusted environments.\n- **Standard** (default): Vault access + most tools, excluding SSH. Good balance of capability and safety.\n- **Admin**: Full access including SSH. All tools available, no confirmation prompts. Maximum capability.\n\nChange the mode at any time — it takes effect immediately.' },
+        { h: '2. Tool Confirmation System', p: 'In Standard and Restricted modes, certain tools require your confirmation before execution. These include: file operations (write, delete), email sending, home assistant state changes, SSH commands, and browser interactions. The confirmation dialog blocks execution until you approve or deny.', tip: 'In Admin mode, all tools run without confirmation. This is the "fully autonomous" mode described on the landing page.' },
+        { h: '3. Permission Mode (Bash/SSH)', p: 'Environment variable `MYND_PERMISSION_MODE` controls confirmation for bash and SSH commands:\n\n- **auto**: All commands allowed without confirmation\n- **semi**: Confirmation only for critical commands (rm, sudo, dd, mkfs, shutdown)\n- **ask**: Confirmation for every command (default)\n\nSet this in your `.env` file or export it before starting MYND.' },
+        { h: '4. Authentication', p: 'All API endpoints except login, registration, and health checks require authentication. Users can have role `user` or `admin`. Admin users can manage plugins, create/delete users, and reset the application. Registration can be enabled/disabled in Settings → Admin.', tip: 'Session tokens expire after 30 days of inactivity. Use Settings → Profile to change your password.' },
+        { h: '5. Data Privacy', p: 'All your data stays on your infrastructure. MYND never sends files or credentials to external servers (unless you configure an external AI provider). The cloud browser runs in a sandboxed environment on your server. Plugin state is stored locally in `plugin_state.json`.' },
+      ],
+    },
+    de: {
+      title: 'Sicherheit & Modi',
+      intro: 'MYND bietet mehrere Sicherheitsebenen und Betriebsmodi. Das Verständnis hilft dir, Komfort und Sicherheit optimal zu balancieren.',
+      steps: [
+        { h: '1. Sicherheitsmodi', p: 'Settings → AI → Security Mode kontrolliert, welche Tools die KI nutzen darf:\n\n- **Eingeschränkt**: Nur Dokumentsuche und Gedächtnis. Keine externen Tools.\n- **Standard** (Standard): Vault-Zugriff + die meisten Tools, außer SSH.\n- **Admin**: Voller Zugriff inkl. SSH. Alle Tools, keine Bestätigungsdialoge.' },
+        { h: '2. Tool-Bestätigung', p: 'Im Standard-Modus benötigen bestimmte Tools deine Bestätigung: Datei-Operationen, E-Mail-Versand, Home-Assistant-Schaltbefehle, Browser-Interaktionen. Der Bestätigungsdialog blockiert die Ausführung bis zur Freigabe.', tip: 'Im Admin-Modus laufen alle Tools ohne Bestätigung — der "vollautonome" Modus.' },
+        { h: '3. Berechtigungsmodus (Bash/SSH)', p: 'Die Umgebungsvariable `MYND_PERMISSION_MODE` steuert die Bestätigung für Bash- und SSH-Befehle:\n\n- **auto**: Alle Befehle erlaubt\n- **semi**: Nur bei kritischen Befehlen (rm, sudo, dd)\n- **ask**: Bei jedem Befehl (Standard)' },
+        { h: '4. Authentifizierung', p: 'Alle API-Endpunkte außer Login, Registrierung und Health-Check erfordern Authentifizierung. Benutzer haben die Rolle `user` oder `admin`. Admins verwalten Plugins, Benutzer und können die App zurücksetzen.' },
+        { h: '5. Datenschutz', p: 'Alle deine Daten bleiben auf deiner Infrastruktur. MYND sendet niemals Dateien oder Zugangsdaten an externe Server (außer bei Konfiguration eines externen KI-Anbieters).' },
       ],
     },
   },
   nextcloud: {
-    de: {
-      title: 'Nextcloud',
-      intro: 'Verbinde MYND mit deiner Nextcloud-Instanz, um Dateien zu durchsuchen, Kalender und Aufgaben abzurufen.',
-      steps: [
-        { h: 'Nextcloud-URL eintragen', p: 'Gehe in die Einstellungen → Nextcloud. Trage die URL deiner Nextcloud-Instanz ein (z.B. https://nextcloud.example.com).' },
-        { h: 'Anmeldedaten hinterlegen', p: 'Gib Benutzername und Passwort ein. MYND nutzt WebDAV für Dateien und CalDAV für Kalender.' },
-        { h: 'Verbindung testen', p: 'Klicke auf "Verbinden". Bei Erfolg siehst du deine Nextcloud-Dateien und Kalender.' },
-        { h: 'Nutzung', p: 'Frage MYND: "Was gibt es Neues in Nextcloud?" oder "Zeige meine Termine für morgen."' },
-      ],
-    },
     en: {
       title: 'Nextcloud',
-      intro: 'Connect MYND to your Nextcloud instance to browse files, fetch calendars and tasks.',
+      intro: 'Connect MYND to your Nextcloud instance to browse files, manage calendars and tasks, and search your cloud storage.',
       steps: [
-        { h: 'Enter Nextcloud URL', p: 'Go to Settings → Nextcloud. Enter your Nextcloud instance URL (e.g. https://nextcloud.example.com).' },
-        { h: 'Enter credentials', p: 'Enter your username and password. MYND uses WebDAV for files and CalDAV for calendars.' },
-        { h: 'Test the connection', p: 'Click "Connect". On success, you\'ll see your Nextcloud files and calendars.' },
-        { h: 'Usage', p: 'Ask MYND: "What\'s new in Nextcloud?" or "Show my appointments for tomorrow."' },
+        { h: '1. Create an app password', p: 'In Nextcloud, go to Settings → Security → "Create app password". Enter a name like "MYND" and copy the generated password. App passwords are preferred over your main password because they can be revoked individually.' },
+        { h: '2. Enter connection details in MYND', p: 'Go to Settings → Integrations → Nextcloud. Enter your Nextcloud URL (e.g. `https://nextcloud.example.com`), your username, and the app password. Click "Connect". MYND tests WebDAV and CalDAV connectivity.' },
+        { h: '3. Browse and search files', p: 'MYND accesses your files via WebDAV. Supported formats: PDF, TXT, DOCX, ODT, Markdown, JSON, YAML, XML, HTML, CSV, and source code files. Ask: "Search my Nextcloud for the budget spreadsheet" or "What documents were modified this week?"' },
+        { h: '4. Calendars and Tasks', p: 'Via CalDAV, MYND reads your calendars and task lists. Ask: "What appointments do I have tomorrow?", "Show my open tasks", "Create an event for Friday at 3 PM".', tip: 'Calendar events and tasks are read-only for safety. Use the Nextcloud UI for modifications, or ask MYND to draft the event details.' },
+        { h: '5. Example queries', p: '— "Search my Nextcloud for files containing invoice2025"\n— "Show me files shared with me"\n— "What changed in the Projects folder this week?"\n— "List my upcoming calendar events"\n— "Find the document tagged with important"', tip: 'The initial indexing scans recent files. For deeper searches across all files, allow a few minutes for full indexing.' },
+      ],
+    },
+    de: {
+      title: 'Nextcloud',
+      intro: 'Verbinde MYND mit deiner Nextcloud-Instanz für Dateisuche, Kalender- und Aufgabenverwaltung.',
+      steps: [
+        { h: '1. App-Passwort erstellen', p: 'In Nextcloud unter Einstellungen → Sicherheit → "App-Passwort erstellen". Namen wie "MYND" vergeben und das generierte Passwort kopieren.' },
+        { h: '2. Verbindung in MYND einrichten', p: 'Settings → Integrations → Nextcloud. URL (z.B. `https://nextcloud.example.com`), Benutzername und App-Passwort eintragen. "Connect" klicken.' },
+        { h: '3. Dateien durchsuchen', p: 'MYND greift über WebDAV auf Dateien zu. Unterstützte Formate: PDF, TXT, DOCX, ODT, Markdown, Code-Dateien. Frage: "Suche in Nextcloud nach der Budget-Tabelle".' },
+        { h: '4. Kalender und Aufgaben', p: 'Über CalDAV liest MYND Kalender und Aufgabenlisten. Frage: "Was habe ich morgen für Termine?", "Zeige meine offenen Aufgaben".', tip: 'Kalender und Aufgaben sind schreibgeschützt. Änderungen im Nextcloud-UI vornehmen.' },
+        { h: '5. Beispiel-Abfragen', p: '— "Suche in Nextcloud nach Rechnung 2025"\n— "Zeige meine geteilten Dateien"\n— "Was hat sich diese Woche im Projekte-Ordner geändert?"' },
       ],
     },
   },
   immich: {
-    de: {
-      title: 'Immich',
-      intro: 'Verbinde MYND mit Immich für KI-gestützte Fotoverwaltung und -Suche.',
-      steps: [
-        { h: 'Immich-URL eintragen', p: 'Gehe zu den Einstellungen → Immich. Trage die URL deines Immich-Servers ein.' },
-        { h: 'API-Key erstellen', p: 'In Immich: Gehe zu Einstellungen → API-Key und erstelle einen neuen Key. Kopiere ihn nach MYND.' },
-        { h: 'Verbindung testen', p: 'Klicke auf "Verbinden". Bei Erfolg siehst du deine Fotobibliothek.' },
-        { h: 'Nutzung', p: 'Frage: "Zeige Fotos von letzter Woche" oder "Finde Bilder mit Hunden."' },
-      ],
-    },
     en: {
       title: 'Immich',
-      intro: 'Connect MYND to Immich for AI-powered photo management and search.',
+      intro: 'Connect MYND to Immich for AI-powered photo search using natural language.',
       steps: [
-        { h: 'Enter Immich URL', p: 'Go to Settings → Immich. Enter your Immich server URL.' },
-        { h: 'Create API key', p: 'In Immich: Go to Settings → API Key and create a new key. Copy it into MYND.' },
-        { h: 'Test connection', p: 'Click "Connect". On success, your photo library will be available.' },
-        { h: 'Usage', p: 'Ask: "Show photos from last week" or "Find pictures with dogs."' },
+        { h: '1. Create an API key', p: 'In Immich, go to Settings → Users → API Key. Create a new key named "MYND" and copy it. The key is shown only once.' },
+        { h: '2. Enter details in MYND', p: 'Settings → Integrations → Immich. Enter your Immich URL and the API key. Click "Connect". MYND will verify it can access your library.' },
+        { h: '3. Search your photos', p: 'MYND queries Immich\'s search API which automatically tags faces, objects, places, and scenes. Ask: "Show photos from last summer", "Find pictures with dogs", "What photos did I take in Paris?"' },
+        { h: '4. Filter by metadata', p: 'You can combine filters: camera model, date range, location, people, and objects. Ask: "Show photos from 2024 taken with my Sony camera", "Find pictures of Anna from the beach vacation".', tip: 'MYND searches metadata only — your original photos stay in Immich. No images are transferred to MYND.' },
+      ],
+    },
+    de: {
+      title: 'Immich',
+      intro: 'Verbinde MYND mit Immich für KI-gestützte Fotosuche in natürlicher Sprache.',
+      steps: [
+        { h: '1. API-Key erstellen', p: 'In Immich unter Settings → Users → API Key. Neuen Key mit Name "MYND" erstellen und kopieren.' },
+        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → Immich. URL und API-Key eintragen. "Connect" klicken.' },
+        { h: '3. Fotos durchsuchen', p: 'MYND nutzt die Immich-Suche mit automatischer Gesichts-, Objekt- und Ortserkennung. Frage: "Zeige Fotos vom letzten Sommer", "Finde Bilder mit Hunden".' },
+        { h: '4. Nach Metadaten filtern', p: 'Kombiniere Filter: Kameramodell, Datumsbereich, Ort, Personen. Frage: "Zeige Fotos von 2024 mit meiner Sony-Kamera".', tip: 'MYND durchsucht nur Metadaten — Originalfotos bleiben in Immich.' },
       ],
     },
   },
   homeassistant: {
-    de: {
-      title: 'Home Assistant',
-      intro: 'Steuere dein Smart Home über MYND — frage nach Zuständen und schalte Geräte.',
-      steps: [
-        { h: 'Long-Lived Token erstellen', p: 'In Home Assistant: Gehe zu deinem Profil → "Langzeit-Zugriffstoken" und erstelle einen neuen Token.' },
-        { h: 'URL und Token eintragen', p: 'In MYND-Einstellungen → Home Assistant: Trage die URL (z.B. http://homeassistant.local:8123) und den Token ein.' },
-        { h: 'Nutzung', p: 'Frage: "Wie ist die Temperatur im Wohnzimmer?" oder "Schalte das Licht im Büro aus."' },
-      ],
-    },
     en: {
       title: 'Home Assistant',
-      intro: 'Control your smart home through MYND — query states and toggle devices.',
+      intro: 'Control your smart home through MYND — check sensors, toggle devices, and trigger automations.',
       steps: [
-        { h: 'Create Long-Lived Token', p: 'In Home Assistant: Go to your profile → "Long-Lived Access Token" and create a new token.' },
-        { h: 'Enter URL and Token', p: 'In MYND Settings → Home Assistant: Enter the URL (e.g. http://homeassistant.local:8123) and the token.' },
-        { h: 'Usage', p: 'Ask: "What\'s the temperature in the living room?" or "Turn off the office light."' },
+        { h: '1. Create a Long-Lived Access Token', p: 'In Home Assistant, click your profile (bottom-left) → "Long-Lived Access Token". Create a token named "MYND" and copy it.' },
+        { h: '2. Enter details in MYND', p: 'Settings → Integrations → Home Assistant. Enter the URL (e.g. `http://homeassistant.local:8123`) and the token. Click "Connect".' },
+        { h: '3. Check states', p: 'MYND reads all entity states. Ask: "What is the temperature in the living room?", "Is the front door locked?", "What is the energy consumption today?"' },
+        { h: '4. Control devices', p: 'Toggle devices and set values. Ask: "Turn off all lights", "Set the thermostat to 21 degrees", "Activate the good night scene".', tip: 'In Standard mode, state-changing actions require your confirmation. Switch to Admin mode in Settings → AI for autonomous control.' },
+      ],
+    },
+    de: {
+      title: 'Home Assistant',
+      intro: 'Steuere dein Smart Home über MYND — Sensoren abfragen, Geräte schalten und Automationen auslösen.',
+      steps: [
+        { h: '1. Long-Lived Token erstellen', p: 'In Home Assistant Profil → "Langzeit-Zugriffstoken". Token mit Name "MYND" erstellen und kopieren.' },
+        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → Home Assistant. URL (z.B. `http://homeassistant.local:8123`) und Token eintragen.' },
+        { h: '3. Zustände abfragen', p: 'Frage: "Wie ist die Temperatur im Wohnzimmer?", "Ist die Haustür verriegelt?", "Wie hoch ist der Stromverbrauch heute?"' },
+        { h: '4. Geräte steuern', p: 'Frage: "Schalte alle Lichter aus", "Stelle den Thermostat auf 21 Grad", "Aktiviere die Gute-Nacht-Szene".', tip: 'Im Standard-Modus benötigen Schaltbefehle Bestätigung. Admin-Modus für autonome Steuerung.' },
       ],
     },
   },
   email: {
-    de: {
-      title: 'E-Mail',
-      intro: 'Verbinde MYND mit deinem E-Mail-Postfach über IMAP/SMTP.',
-      steps: [
-        { h: 'IMAP/SMTP-Daten bereithalten', p: 'Du benötigst: IMAP-Server (für Empfang), SMTP-Server (für Versand), Benutzername und Passwort.' },
-        { h: 'Konto einrichten', p: 'In MYND-Einstellungen → E-Mail: Lege ein neues Konto an. Gängige Anbieter (Gmail, Outlook, etc.) haben vorgegebene Ports.' },
-        { h: 'Verbindung testen', p: 'Klicke auf "Verbinden". MYND testet IMAP und SMTP getrennt.' },
-        { h: 'Hinweis', p: 'Bei Gmail benötigst du ein App-Passwort. Bei selbstgehosteten Servern stelle sicher, dass IMAP und SMTP freigegeben sind.' },
-      ],
-    },
     en: {
       title: 'Email',
-      intro: 'Connect MYND to your email inbox via IMAP/SMTP.',
+      intro: 'Connect MYND to your mailbox via IMAP/SMTP — search, read, and send emails.',
       steps: [
-        { h: 'Prepare IMAP/SMTP details', p: 'You need: IMAP server (for receiving), SMTP server (for sending), username and password.' },
-        { h: 'Set up account', p: 'In MYND Settings → Email: Create a new account. Common providers (Gmail, Outlook, etc.) have preset ports.' },
-        { h: 'Test connection', p: 'Click "Connect". MYND tests IMAP and SMTP separately.' },
-        { h: 'Note', p: 'For Gmail you need an app password. For self-hosted servers, make sure IMAP and SMTP are enabled.' },
+        { h: '1. Prepare your credentials', p: 'You need IMAP/SMTP server addresses, ports, and credentials. Common providers:\n\n- **Gmail**: imap.gmail.com:993, smtp.gmail.com:587 (requires app password)\n- **Outlook**: outlook.office365.com:993, smtp.office365.com:587\n- **Custom**: Use your mail server addresses' },
+        { h: '2. Add account in MYND', p: 'Settings → Integrations → Email → "Add Account". Enter server details and credentials. MYND tests both IMAP (receiving) and SMTP (sending) connections.' },
+        { h: '3. Search and read', p: 'MYND indexes recent emails. Ask: "Show my unread emails", "Find the invoice from last month", "Summarize emails from [sender]"', tip: 'For Gmail, use an App Password (Settings → Security → App Passwords). Your regular password may not work with IMAP/SMTP.' },
+        { h: '4. Send emails', p: 'MYND can send emails on your behalf. Ask: "Send an email to john@example.com with subject Meeting and body: Let us meet at 3 PM tomorrow."' },
+      ],
+    },
+    de: {
+      title: 'E-Mail',
+      intro: 'Verbinde MYND mit deinem Postfach — E-Mails suchen, lesen und senden.',
+      steps: [
+        { h: '1. Zugangsdaten vorbereiten', p: 'IMAP/SMTP-Server, Ports und Anmeldedaten. Übliche Anbieter:\n\n- **Gmail**: imap.gmail.com:993, smtp.gmail.com:587 (App-Passwort nötig)\n- **Outlook**: outlook.office365.com:993, smtp.office365.com:587' },
+        { h: '2. Konto hinzufügen', p: 'Settings → Integrations → Email → "Add Account". Server-Daten eintragen. MYND testet IMAP und SMTP getrennt.' },
+        { h: '3. Suchen und lesen', p: 'Frage: "Zeige meine ungelesenen E-Mails", "Finde die Rechnung vom letzten Monat".', tip: 'Bei Gmail ein App-Passwort verwenden (Settings → Sicherheit → App-Passwörter).' },
+        { h: '4. E-Mails senden', p: 'Frage: "Sende eine E-Mail an max@example.com mit Betreff Besprechung und Inhalt: Treffen morgen um 15 Uhr."' },
       ],
     },
   },
   spotify: {
-    de: {
-      title: 'Spotify',
-      intro: 'Steuere Spotify über MYND — suche Titel, steuere die Wiedergabe und verwalte Playlists.',
-      steps: [
-        { h: 'Client-ID und Secret besorgen', p: 'Gehe zum Spotify Developer Dashboard (https://developer.spotify.com/dashboard) und erstelle eine App. Kopiere Client-ID und Client-Secret.' },
-        { h: 'Redirect-URI setzen', p: 'Setze in der Spotify-App die Redirect-URI auf http://localhost:5001/callback/spotify (oder deine Produktions-URL).' },
-        { h: 'In MYND einrichten', p: 'Gehe zu den Einstellungen → Spotify. Trage Client-ID und Secret ein und autorisiere die Verbindung.' },
-        { h: 'Nutzung', p: 'Frage: "Spiele Musik von [Künstler]" oder "Was läuft gerade in meinen Playlists?"' },
-      ],
-    },
     en: {
       title: 'Spotify',
-      intro: 'Control Spotify through MYND — search tracks, control playback and manage playlists.',
+      intro: 'Control Spotify playback through MYND — search, play, and manage playlists via the official Spotify Web API.',
       steps: [
-        { h: 'Get Client ID and Secret', p: 'Go to the Spotify Developer Dashboard (https://developer.spotify.com/dashboard) and create an app. Copy the Client ID and Client Secret.' },
-        { h: 'Set Redirect URI', p: 'In the Spotify app, set the Redirect URI to http://localhost:5001/callback/spotify (or your production URL).' },
-        { h: 'Set up in MYND', p: 'Go to Settings → Spotify. Enter Client ID and Secret and authorize the connection.' },
-        { h: 'Usage', p: 'Ask: "Play music by [artist]" or "What\'s playing in my playlists?"' },
+        { h: '1. Create a Spotify app', p: 'Go to https://developer.spotify.com/dashboard → "Create App". Name it "MYND". Set the Redirect URI to `http://localhost:5001/callback/spotify`. Copy the Client ID and Client Secret.' },
+        { h: '2. Connect in MYND', p: 'Settings → Integrations → Spotify. Enter Client ID and Secret. Click "Connect" — you will be redirected to Spotify to authorize. MYND stores the refresh token for permanent access.' },
+        { h: '3. Control playback', p: 'Ask: "Play [song] by [artist]", "Pause", "Next track", "What is currently playing?", "Play my Discover Weekly playlist".', tip: 'Spotify Premium is required for playback control. The free tier only allows read access.' },
+        { h: '4. Manage playlists', p: 'Ask: "Create a playlist called Morning Vibes", "Add this song to my Favorites playlist".', tip: 'For production, update the Redirect URI to your actual domain in the Spotify Developer Dashboard.' },
+      ],
+    },
+    de: {
+      title: 'Spotify',
+      intro: 'Steuere Spotify über MYND — Titel suchen, abspielen und Playlists verwalten.',
+      steps: [
+        { h: '1. Spotify-App erstellen', p: 'https://developer.spotify.com/dashboard → "Create App". Name "MYND". Redirect-URI: `http://localhost:5001/callback/spotify`. Client-ID und Secret kopieren.' },
+        { h: '2. In MYND verbinden', p: 'Settings → Integrations → Spotify. Client-ID und Secret eintragen. "Connect" — du wirst zu Spotify weitergeleitet.' },
+        { h: '3. Wiedergabe steuern', p: 'Frage: "Spiele [Song] von [Künstler]", "Pausiere", "Nächster Titel", "Spiele meine Discover Weekly Playlist".', tip: 'Spotify Premium erforderlich für Wiedergabesteuerung.' },
+        { h: '4. Playlists verwalten', p: 'Frage: "Erstelle eine Playlist mit Namen", "Füge diesen Song zu meiner Favorites-Playlist hinzu".' },
       ],
     },
   },
   discord: {
-    de: {
-      title: 'Discord',
-      intro: 'Verbinde MYND mit Discord, um Nachrichten zu lesen, zu senden und Kanäle zu durchsuchen.',
-      steps: [
-        { h: 'Discord-App erstellen', p: 'Gehe zum Discord Developer Portal (https://discord.com/developers/applications) und erstelle eine neue App.' },
-        { h: 'Bot erstellen', p: 'Gehe zu "Bot" und erstelle einen Bot. Kopiere den Token.' },
-        { h: 'Bot einladen', p: 'Erstelle einen OAuth2-Link mit den Berechtigungen "Send Messages", "Read Message History", "View Channels". Lade den Bot auf deinen Server ein.' },
-        { h: 'In MYND einrichten', p: 'Gehe zu den Einstellungen → Discord. Trage den Bot-Token ein.' },
-      ],
-    },
     en: {
       title: 'Discord',
-      intro: 'Connect MYND to Discord to read and send messages and search channels.',
+      intro: 'Connect MYND to Discord — read messages, search channels, and send messages via a dedicated bot.',
       steps: [
-        { h: 'Create Discord App', p: 'Go to the Discord Developer Portal (https://discord.com/developers/applications) and create a new app.' },
-        { h: 'Create Bot', p: 'Go to "Bot" and create a bot. Copy the token.' },
-        { h: 'Invite Bot', p: 'Create an OAuth2 URL with "Send Messages", "Read Message History", "View Channels" permissions. Invite the bot to your server.' },
-        { h: 'Set up in MYND', p: 'Go to Settings → Discord. Enter the bot token.' },
+        { h: '1. Create a Discord bot', p: 'Go to https://discord.com/developers/applications → "New Application" → "Bot" → "Add Bot". Copy the token. Enable "Message Content Intent" and "Server Members Intent".' },
+        { h: '2. Invite the bot', p: 'Go to "OAuth2" → "URL Generator". Select "bot" with permissions: Send Messages, Read Message History, View Channels, Read Messages. Open the URL and select your server.', tip: 'You need "Manage Server" permissions to invite the bot.' },
+        { h: '3. Enter token in MYND', p: 'Settings → Integrations → Discord. Enter the bot token. Click "Connect". MYND will list your servers and channels.' },
+        { h: '4. Use it', p: 'Ask: "What is new on the [server] server?", "Search Discord for the project link", "Send a message to #general: I will be there in 5 minutes".', tip: 'MYND cannot read DMs — only channels the bot is a member of.' },
+      ],
+    },
+    de: {
+      title: 'Discord',
+      intro: 'Verbinde MYND mit Discord — Nachrichten lesen, Kanäle durchsuchen und senden.',
+      steps: [
+        { h: '1. Discord-Bot erstellen', p: 'https://discord.com/developers/applications → "New Application" → "Bot" → "Add Bot". Token kopieren. "Message Content Intent" aktivieren.' },
+        { h: '2. Bot einladen', p: '"OAuth2" → "URL Generator". "bot" auswählen mit Berechtigungen: Send Messages, Read Message History, View Channels.', tip: '"Manage Server"-Rechte erforderlich.' },
+        { h: '3. Token eintragen', p: 'Settings → Integrations → Discord. Bot-Token eintragen. "Connect".' },
+        { h: '4. Nutzung', p: 'Frage: "Was gibt es Neues auf [Server]?", "Suche in Discord nach dem Projekt-Link".' },
       ],
     },
   },
   truenas: {
-    de: {
-      title: 'TrueNAS',
-      intro: 'Überwache dein TrueNAS-System über MYND — Speicherstatus, Dienste und Alerts.',
-      steps: [
-        { h: 'TrueNAS-Zugang vorbereiten', p: 'Stelle sicher, dass SSH auf deinem TrueNAS-Server aktiviert ist und du die Zugangsdaten hast.' },
-        { h: 'Zugangsdaten hinterlegen', p: 'In MYND-Einstellungen → TrueNAS: Trage die IP, den Benutzernamen und das Passwort ein.' },
-        { h: 'Nutzung', p: 'Frage: "Wie ist der Speicherstatus?" oder "Zeige aktuelle TrueNAS-Alerts."' },
-      ],
-    },
     en: {
       title: 'TrueNAS',
-      intro: 'Monitor your TrueNAS system through MYND — storage status, services and alerts.',
+      intro: 'Monitor your TrueNAS system — storage pools, disk health, SMART data, services, and alerts via the TrueNAS API.',
       steps: [
-        { h: 'Prepare TrueNAS access', p: 'Make sure SSH is enabled on your TrueNAS server and you have the credentials ready.' },
-        { h: 'Enter credentials', p: 'In MYND Settings → TrueNAS: Enter the IP, username and password.' },
-        { h: 'Usage', p: 'Ask: "What\'s the storage status?" or "Show current TrueNAS alerts."' },
+        { h: '1. Create an API key', p: 'In TrueNAS, go to Settings → API Keys → "Add". Name it "MYND" and copy the key. It is shown only once.' },
+        { h: '2. Enter details in MYND', p: 'Settings → Integrations → TrueNAS. Enter your TrueNAS URL (e.g. `http://truenas.local:8080`) and the API key. Click "Connect".' },
+        { h: '3. Check storage', p: 'Ask: "How is my storage pool doing?", "How much free space do I have?", "Show me all pools and their usage".' },
+        { h: '4. Monitor health', p: 'Ask: "Are there any disk alerts?", "Show SMART status of all drives", "What services are running?".', tip: 'SMART long tests can take hours. MYND reports the most recent test results.' },
+      ],
+    },
+    de: {
+      title: 'TrueNAS',
+      intro: 'Überwache dein TrueNAS-System — Speicherpools, Festplatten, SMART-Werte und Alarme.',
+      steps: [
+        { h: '1. API-Key erstellen', p: 'In TrueNAS unter Settings → API Keys → "Add". Namen "MYND" vergeben und Key kopieren.' },
+        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → TrueNAS. URL (z.B. `http://truenas.local:8080`) und API-Key eintragen.' },
+        { h: '3. Speicher prüfen', p: 'Frage: "Wie ist der Stand meines Speicherpools?", "Wie viel Speicher ist noch frei?"' },
+        { h: '4. Gesundheit überwachen', p: 'Frage: "Gibt es Festplatten-Alarme?", "Zeige SMART-Status aller Festplatten".', tip: 'SMART-Tests können Stunden dauern. MYND zeigt die letzten Ergebnisse.' },
       ],
     },
   },
   browser: {
-    de: {
-      title: 'Browser',
-      intro: 'MYND enthält einen vollwertigen Cloud-Browser mit Stealth-Modus für Web-Recherche.',
-      steps: [
-        { h: 'Browser-Konfiguration', p: 'MYND nutzt einen browserlosen Cloud-Browser. Keine Einrichtung nötig — er funktioniert sofort.' },
-        { h: 'Verfügbare Aktionen', p: 'MYND kann: Webseiten öffnen, Screenshots machen, Texte extrahieren, Formulare ausfüllen, PDFs exportieren, Downloads verwalten.' },
-        { h: 'Stealth-Modus', p: 'Der Browser verwendet einen separaten User-Agent und Proxy. Keine Cookies oder Sitzungen werden zwischen MYND und deinem normalen Browser geteilt.' },
-        { h: 'Nutzung', p: 'Frage: "Öffne die Seite [URL]" oder "Suche nach [Suchbegriff]" oder "Mach einen Screenshot von [URL]".' },
-      ],
-    },
     en: {
       title: 'Browser',
-      intro: 'MYND includes a full cloud browser with stealth mode for web research.',
+      intro: 'MYND includes a built-in cloud browser for web research — navigate pages, take screenshots, extract text, and interact with forms.',
       steps: [
-        { h: 'Browser setup', p: 'MYND uses a headless cloud browser. No setup required — it works out of the box.' },
-        { h: 'Available actions', p: 'MYND can: open websites, take screenshots, extract text, fill forms, export PDFs, manage downloads.' },
-        { h: 'Stealth mode', p: 'The browser uses a separate user-agent and proxy. No cookies or sessions are shared between MYND and your normal browser.' },
-        { h: 'Usage', p: 'Ask: "Open the page [URL]" or "Search for [query]" or "Take a screenshot of [URL]".' },
+        { h: '1. How it works', p: 'The cloud browser is a headless Chromium instance running on your server. It opens websites, executes JavaScript, and captures screenshots — completely isolated from your regular browser with separate cookies, sessions, and extensions.' },
+        { h: '2. Browse and capture', p: 'Ask: "Open [URL]", "Take a screenshot of [URL]", "Summarize the content of [URL]". The browser renders JavaScript-heavy pages (React, Vue SPAs) before capturing.' },
+        { h: '3. Extract and search', p: 'Ask: "Extract all links from [URL]", "Search the page for [keyword]", "What is the main content of this article?"' },
+        { h: '4. Interact and download', p: 'Ask: "Fill the search form with [query] on [URL]", "Click the login button", "Download the PDF from this page".', tip: 'Browser interactions (clicks, form fills) require confirmation in Standard mode. Switch to Admin mode for autonomous browsing.' },
+      ],
+    },
+    de: {
+      title: 'Browser',
+      intro: 'MYND enthält einen integrierten Cloud-Browser für Web-Recherche — navigieren, Screenshots machen, Texte extrahieren.',
+      steps: [
+        { h: '1. Funktionsweise', p: 'Der Cloud-Browser ist eine server-seitige, isolierte Chromium-Instanz. Keine Cookies oder Sitzungen werden mit deinem normalen Browser geteilt.' },
+        { h: '2. Navigieren und Screenshots', p: 'Frage: "Öffne [URL]", "Mach einen Screenshot von [URL]", "Fasse den Inhalt von [URL] zusammen".' },
+        { h: '3. Extrahieren und suchen', p: 'Frage: "Extrahiere alle Links von [URL]", "Suche auf der Seite nach [Suchbegriff]".' },
+        { h: '4. Interagieren und herunterladen', p: 'Frage: "Fülle das Suchformular auf [URL] mit [Suchbegriff]", "Lade das PDF herunter".', tip: 'Browser-Interaktionen benötigen Bestätigung im Standard-Modus.' },
       ],
     },
   },
 };
 
 export default function GuidePage() {
-  const [lang, setLang] = useState('de');
+  const [lang, setLang] = useState('en');
   const [activeSection, setActiveSection] = useState('getting-started');
 
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem('mynd_language');
-      if (stored === 'en' || stored === 'de') setLang(stored);
-    } catch {}
-    const mode = (() => { try { return localStorage.getItem('darkMode') || 'light'; } catch(e) { return 'light'; } })();
+    const mode = (() => { try { return localStorage.getItem('darkMode') || 'light'; } catch { return 'light'; } })();
     document.documentElement.setAttribute('data-mode', mode);
   }, []);
 
   const t = (de, en) => lang === 'de' ? de : en;
-  const content = GUIDE[activeSection]?.[lang] || GUIDE[activeSection]?.de;
+  const content = GUIDE[activeSection]?.[lang] || GUIDE[activeSection]?.en;
 
   return (
     <div className="lp-guide" lang={lang}>
-      <nav className="lp-guide-nav">
-        <div className="lp-guide-nav-inner">
-          <Link href="/" className="lp-guide-logo">
-            <span className="lp-guide-logo-mark" aria-hidden="true"><i /></span>
+      <nav className="lp-nav">
+        <div className="lp-nav-inner">
+          <Link href="/" className="lp-logo">
+            <span className="lp-logo-mark"><i /></span>
             <span>MYND</span>
           </Link>
-          <div className="lp-guide-nav-links">
+          <div className="lp-nav-links">
             <Link href="/guide">{t('Anleitung', 'Guide')}</Link>
             <Link href="/developers">{t('Entwickler', 'Developers')}</Link>
-            <Link href="/login">{t('Anmelden', 'Sign in')}</Link>
           </div>
-          <button className="lp-guide-lang-toggle" type="button" onClick={() => setLang(l => l === 'de' ? 'en' : 'de')}>
-            {lang === 'de' ? 'EN' : 'DE'}
-          </button>
+          <div className="lp-nav-actions">
+            <button className="lp-language" type="button" onClick={() => setLang(l => l === 'de' ? 'en' : 'de')}>
+              <span className={lang === 'de' ? 'active' : ''}>DE</span>
+              <i />
+              <span className={lang === 'en' ? 'active' : ''}>EN</span>
+            </button>
+            <Link href="/login" className="lp-signin">
+              {t('Anmelden', 'Sign in')} <i className="fas fa-arrow-right" />
+            </Link>
+          </div>
         </div>
       </nav>
 
-      <div className="lp-guide-layout">
+      <div className="lp-guide-layout lp-shell">
         <aside className="lp-guide-sidebar">
           <nav aria-label={t('Navigation', 'Navigation')}>
             {SECTIONS.map(s => (
@@ -283,7 +343,7 @@ export default function GuidePage() {
                 onClick={() => setActiveSection(s.id)}
               >
                 <i className={`fas ${s.icon}`} />
-                {s[`label_${lang}`] || s.label_de}
+                {s[`label_${lang}`] || s.label_en}
               </button>
             ))}
           </nav>
@@ -291,7 +351,7 @@ export default function GuidePage() {
 
         <main className="lp-guide-main">
           {content && (
-            <>
+            <div className="lp-guide-section">
               <h1 className="lp-guide-title">
                 <i className={`fas ${SECTIONS.find(s => s.id === activeSection)?.icon}`} />
                 {' '}{content.title}
@@ -300,15 +360,21 @@ export default function GuidePage() {
               <div className="lp-guide-steps">
                 {content.steps.map((step, i) => (
                   <div key={i} className="lp-guide-step">
-                    <h2 className="lp-guide-step-heading">{step.h}</h2>
+                    <h2 className="lp-guide-step-heading">
+                      <span className="step-num">{String(i + 1).padStart(2, '0')}</span>
+                      {step.h.replace(/^\d+\.\s*/, '')}
+                    </h2>
                     <p>{step.p}</p>
+                    {step.tip && <div className="lp-guide-tip"><strong>{t('Tipp', 'Tip')}:</strong> {step.tip}</div>}
                   </div>
                 ))}
               </div>
-            </>
+            </div>
           )}
           <div className="lp-guide-footer">
-            <Link href="/developers">{t('Entwickler-Dokumentation', 'Developer Documentation')}</Link>
+            <Link href="https://github.com/SchBenedikt/mynd" target="_blank">GitHub</Link>
+            {' · '}
+            <Link href="/developers">{t('Entwickler-Dokumentation', 'Developer Docs')}</Link>
             {' · '}
             <Link href="/login">{t('Zum Login', 'Go to Login')}</Link>
           </div>

--- a/frontend/components/settings/AdminTab.js
+++ b/frontend/components/settings/AdminTab.js
@@ -15,7 +15,7 @@ export default function AdminTab({ tr, language }) {
   const [authConfigMsg, setAuthConfigMsg] = useState('');
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [newUser, setNewUser] = useState({ username: '', password: '', name: '' });
+  const [newUser, setNewUser] = useState({ username: '', password: '', name: '', role: 'user' });
   const [userMsg, setUserMsg] = useState('');
   const [userError, setUserError] = useState('');
 
@@ -176,7 +176,7 @@ export default function AdminTab({ tr, language }) {
                     <div className="user-row-admin-avatar">{(u.name || u.username || '?')[0].toUpperCase()}</div>
                     <div>
                       <div className="user-row-admin-name">{u.name || u.username}</div>
-                      <div className="user-row-admin-username">{u.username}{u.username === 'admin' ? ` (${tr('Admin', 'Admin')})` : ''}</div>
+                      <div className="user-row-admin-username">{u.username}{u.role === 'admin' ? ` (${tr('Admin', 'Admin')})` : ''}</div>
                     </div>
                   </div>
                   <div className="user-row-admin-actions">
@@ -204,6 +204,11 @@ export default function AdminTab({ tr, language }) {
                   placeholder={tr('Anzeigename', 'Display name')} />
                 <input type="password" value={newUser.password} onChange={(e) => setNewUser({...newUser,password:e.target.value})}
                   placeholder={tr('Passwort', 'Password')} />
+                <select value={newUser.role} onChange={(e) => setNewUser({...newUser,role:e.target.value})}
+                  style={{padding:'0.5rem',borderRadius:'8px',border:'1px solid var(--line)',background:'var(--bg)',color:'var(--ink)'}}>
+                  <option value="user">{tr('Benutzer', 'User')}</option>
+                  <option value="admin">{tr('Admin', 'Admin')}</option>
+                </select>
                 <button type="submit" className="btn primary">
                   <i className="fas fa-plus" style={{marginRight:'0.4rem'}}></i>
                   {tr('Erstellen', 'Create')}

--- a/frontend/components/settings/IntegrationsTab.js
+++ b/frontend/components/settings/IntegrationsTab.js
@@ -188,9 +188,9 @@ export default function IntegrationsTab({ tr, language }) {
                   {t('Plugin Manager', 'Plugin Manager')}
                 </div>
                 <p style={{ fontSize: '0.85rem', color: 'var(--muted)', margin: '0.25rem 0 0' }}>
-                  {t(`${plugins.length} Plugin(s)`, `${plugins.length} plugin(s)`)}
+                  {t(`${plugins.filter(p => p.name !== 'system' && p.name !== 'python_exec').length} Plugin(s)`, `${plugins.filter(p => p.name !== 'system' && p.name !== 'python_exec').length} plugin(s)`)}
                   {' · '}
-                  {t(`${plugins.filter(p => p.enabled).length} aktiv`, `${plugins.filter(p => p.enabled).length} active`)}
+                  {t(`${plugins.filter(p => p.name !== 'system' && p.name !== 'python_exec' && p.enabled).length} aktiv`, `${plugins.filter(p => p.name !== 'system' && p.name !== 'python_exec' && p.enabled).length} active`)}
                 </p>
               </div>
             </div>
@@ -205,7 +205,7 @@ export default function IntegrationsTab({ tr, language }) {
               </div>
             ) : (
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                {plugins.map(p => (
+                {plugins.filter(p => p.name !== 'system' && p.name !== 'python_exec').map(p => (
                   <div key={p.name} style={{ border: '1px solid var(--line)', borderRadius: 'var(--radius)', padding: '1rem', background: 'var(--card-bg)', opacity: p.enabled ? 1 : 0.45 }}>
                     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
                       <label style={{ position: 'relative', display: 'inline-block', width: 36, height: 20, flexShrink: 0, marginTop: 2 }}>


### PR DESCRIPTION
- Fix: WEB_TOOL_MAP now mutates in-place so all imports see plugin tools (fixes 'Unknown tool: timer_set')
- Fix: Tool confirmation obeys security mode — Admin mode = no confirmations
- Fix: Tool confirmation dialog properly centered with overlay + backdrop blur
- Fix: Admin users can create other admin users (role selector in user creation)
- Fix: system + python_exec plugins hidden from Plugin Manager (core plugins)
- New: Guide page now has Architecture + Security & Modes sections
- New: AI Models section with hardware/RAM/tool-support comparison table
- Update: All guide sections deeply expanded with tips, examples, config details
- Update: /api/admin/users now returns role field