### PR TITLE
fix: guide page matches developers design, expanded LP, default English

### DIFF
--- a/frontend/app/guide/guide.css
+++ b/frontend/app/guide/guide.css
@@ -1,15 +1,12 @@
 html:has(.lp-guide),
 html:has(.lp-guide) body {
-  height: auto;
-  min-height: 100%;
-  overflow: visible;
+  height: auto; min-height: 100%; overflow: visible; scroll-behavior: smooth;
 }
 
 .lp-guide {
   --lp-bg: #090a0e;
   --lp-bg-raised: #0e1016;
   --lp-panel: #12151d;
-  --lp-panel-2: #171a23;
   --lp-ink: #f2f3f8;
   --lp-body: #c3c7d2;
   --lp-muted: #9298a8;
@@ -19,15 +16,12 @@ html:has(.lp-guide) body {
   --lp-accent: #91a0ff;
   --lp-accent-strong: #7185ff;
   --lp-accent-soft: rgba(145, 160, 255, 0.12);
-  --lp-signal: #e28b5c;
   --lp-grid: rgba(255,255,255,.018);
   --lp-mono: var(--font-ibm-plex-mono), monospace;
-  position: relative;
-  min-height: 100vh;
-  overflow: hidden;
   color: var(--lp-ink);
   background: var(--lp-bg);
   font-family: var(--font-space-grotesk), sans-serif;
+  min-height: 100vh;
   isolation: isolate;
 }
 
@@ -35,7 +29,6 @@ html:has(.lp-guide) body {
   --lp-bg: #f4f6fb;
   --lp-bg-raised: #eef0f6;
   --lp-panel: #ffffff;
-  --lp-panel-2: #f8f9fd;
   --lp-ink: #151820;
   --lp-body: #464b5a;
   --lp-muted: #7c8295;
@@ -45,207 +38,383 @@ html:has(.lp-guide) body {
   --lp-accent: #6b7dff;
   --lp-accent-strong: #5570f0;
   --lp-accent-soft: rgba(107, 125, 255, 0.08);
-  --lp-signal: #d97742;
   --lp-grid: rgba(0,0,0,.035);
 }
 
 [data-mode="light"] .lp-guide-nav { background: rgba(244, 246, 251, .91); }
-[data-mode="light"] .lp-guide-sidebar-link:hover { background: var(--lp-accent-soft); }
 
 .lp-guide::before {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
+  position: fixed; inset: 0; z-index: -1;
   background-image:
     linear-gradient(var(--lp-grid) 1px, transparent 1px),
     linear-gradient(90deg, var(--lp-grid) 1px, transparent 1px);
   background-size: 64px 64px;
   mask-image: linear-gradient(to bottom, rgba(0,0,0,.7), transparent 48%);
-  content: '';
-  pointer-events: none;
+  content: ''; pointer-events: none;
 }
 
-.lp-guide a,
-.lp-guide button { -webkit-tap-highlight-color: transparent; }
-.lp-guide a:focus-visible,
-.lp-guide button:focus-visible { outline: 2px solid var(--lp-accent); outline-offset: 4px; }
+.lp-guide a, .lp-guide button { -webkit-tap-highlight-color: transparent; }
+.lp-guide a:focus-visible, .lp-guide button:focus-visible { outline: 2px solid var(--lp-accent); outline-offset: 4px; }
 
+.lp-guide-shell {
+  width: min(1280px, calc(100% - 64px));
+  margin-inline: auto;
+}
+
+/* Nav */
 .lp-guide-nav {
-  position: sticky;
-  inset: 0 0 auto;
-  z-index: 50;
+  position: sticky; inset: 0 0 auto; z-index: 50;
   border-bottom: 1px solid var(--lp-line);
-  background: rgba(9, 10, 14, .91);
+  background: rgba(9,10,14,.91);
   backdrop-filter: blur(18px) saturate(115%);
   -webkit-backdrop-filter: blur(18px) saturate(115%);
 }
-
 .lp-guide-nav-inner {
   width: min(1280px, calc(100% - 64px));
   min-height: 72px;
   margin-inline: auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
 }
-
 .lp-guide-logo {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 1.1rem;
-  font-weight: 700;
-  color: var(--lp-ink);
-  text-decoration: none;
+  display: inline-flex; min-height: 44px; align-items: center; gap: .72rem;
+  color: var(--lp-ink); font-size: 1rem; font-weight: 650;
+  letter-spacing: .17em; text-decoration: none;
 }
-
-.lp-guide-logo-mark i {
-  display: block;
-  width: 32px;
-  height: 32px;
-  background: linear-gradient(135deg, var(--lp-accent), var(--lp-accent-strong));
-  border-radius: 8px;
+.lp-guide-logo-mark {
+  position: relative; width: 20px; height: 20px;
+  display: inline-grid; place-items: center;
+  border: 1px solid var(--lp-accent); transform: rotate(45deg);
 }
-
+.lp-guide-logo-mark i { width: 5px; height: 5px; display: block; background: var(--lp-accent); }
 .lp-guide-nav-links {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+  display: flex; gap: clamp(.6rem, 1.6vw, 1.2rem); margin-left: auto;
+  overflow-x: auto; scrollbar-width: none;
 }
-
 .lp-guide-nav-links a {
-  padding: 6px 14px;
-  font-size: .85rem;
-  font-weight: 600;
-  color: var(--lp-muted);
-  text-decoration: none;
-  border-radius: 8px;
-  transition: all .15s ease;
+  min-height: 44px; display: flex; align-items: center;
+  color: var(--lp-muted); font: 500 .72rem/1 var(--lp-mono);
+  text-decoration: none; white-space: nowrap;
+  transition: color .2s ease;
 }
+.lp-guide-nav-links a:hover,
+.lp-guide-nav-links a.is-active { color: var(--lp-ink); }
+.lp-guide-nav-actions { display: flex; align-items: center; margin-left: 1.5rem; }
+.lp-guide-lang {
+  min-width: 82px; min-height: 44px;
+  display: flex; align-items: center; justify-content: center; gap: .5rem;
+  border: 1px solid var(--lp-line);
+  color: var(--lp-muted); background: transparent;
+  font: 500 .75rem/1 var(--lp-mono);
+  cursor: pointer; transition: border-color .2s ease, color .2s ease, background .2s ease;
+}
+.lp-guide-lang:hover { border-color: var(--lp-line-strong); background: rgba(255,255,255,.025); }
+.lp-guide-lang i { width: 1px; height: 12px; background: var(--lp-line-strong); }
+.lp-guide-lang .active { color: var(--lp-ink); }
 
-.lp-guide-nav-links a:hover { color: var(--lp-ink); background: var(--lp-accent-soft); }
-
-.lp-guide-lang-toggle {
-  padding: 6px 14px;
-  border-radius: 999px;
-  border: 1px solid var(--lp-line-strong);
-  background: var(--lp-panel);
+/* Hero */
+.lp-guide-hero { position: relative; border-bottom: 1px solid var(--lp-line); }
+.lp-guide-hero::before {
+  position: absolute; inset: 0; z-index: -1;
+  background: radial-gradient(circle at 75% 28%, rgba(113,133,255,.1), transparent 23%);
+  content: '';
+}
+.lp-guide-hero .lp-guide-shell {
+  min-height: 400px;
+  display: flex; flex-direction: column; justify-content: center;
+  padding-block: clamp(4rem, 8vw, 6rem);
+  animation: lp-guide-enter .7s cubic-bezier(.2,.7,.2,1) both;
+}
+.lp-guide-eyebrow {
+  display: flex; align-items: center; gap: .7rem; margin: 0 0 1.8rem;
+  color: var(--lp-accent);
+  font: 500 .75rem/1.55 var(--lp-mono);
+  letter-spacing: .09em;
+  text-transform: uppercase;
+}
+.lp-guide-live-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--lp-accent);
+  box-shadow: 0 0 0 4px rgba(145,160,255,.12);
+  animation: lp-guide-status 2.6s ease-in-out infinite;
+}
+.lp-guide-hero h1 {
+  max-width: 760px; margin: 0;
+  font-size: clamp(2.4rem, 4.2vw, 4.2rem);
+  font-weight: 520; letter-spacing: -.03em; line-height: 1.15;
+}
+.lp-guide-lede {
+  max-width: 570px; margin: 1.4rem 0 0;
   color: var(--lp-body);
-  font-size: .82rem;
-  font-weight: 600;
-  cursor: pointer;
-  font-family: var(--lp-mono);
-  transition: all .15s ease;
+  font-size: clamp(1rem, 1.25vw, 1.12rem); line-height: 1.72;
 }
+.lp-guide-hero-actions {
+  display: flex; align-items: center; gap: 1.5rem; margin-top: 2.2rem;
+}
+.lp-guide-primary-cta {
+  min-height: 52px;
+  display: inline-flex; align-items: center; justify-content: center;
+  gap: .85rem; padding: 0 1.35rem;
+  border: 1px solid var(--lp-accent-strong);
+  color: #fff; background: var(--lp-accent-strong);
+  font-size: .84rem; font-weight: 650; text-decoration: none;
+  transition: background .2s ease, box-shadow .2s ease;
+}
+.lp-guide-primary-cta:hover { background: #8091ff; box-shadow: 0 0 24px rgba(113,133,255,.2); }
+.lp-guide-primary-cta i { font-size: .72rem; }
+.lp-guide-secondary-cta {
+  min-height: 44px;
+  display: inline-flex; align-items: center; gap: .65rem;
+  border-bottom: 1px solid var(--lp-line-strong);
+  color: var(--lp-body);
+  font-size: .8rem; font-weight: 550; text-decoration: none;
+  transition: color .2s ease, border-color .2s ease;
+}
+.lp-guide-secondary-cta:hover { color: var(--lp-ink); border-color: var(--lp-accent); }
+.lp-guide-secondary-cta i { color: var(--lp-accent); font-size: .7rem; }
 
-.lp-guide-lang-toggle:hover { background: var(--lp-panel-2); }
+/* Ticker */
+.lp-guide-ticker { border-bottom: 1px solid var(--lp-line); background: var(--lp-bg-raised); }
+.lp-guide-ticker-track {
+  min-height: 104px;
+  display: grid; grid-template-columns: repeat(3, 1fr);
+}
+.lp-guide-ticker p {
+  min-width: 0;
+  display: grid; grid-template-columns: 32px 1fr;
+  align-content: center; gap: .15rem .8rem;
+  margin: 0;
+  padding: 1.2rem clamp(1rem, 3vw, 2.6rem);
+  border-right: 1px solid var(--lp-line);
+}
+.lp-guide-ticker p:first-child { padding-left: 0; }
+.lp-guide-ticker p:last-child { border: 0; }
+.lp-guide-ticker p > span { grid-row: span 2; align-self: center; color: var(--lp-accent); font: 500 .75rem/1 var(--lp-mono); }
+.lp-guide-ticker strong { font-size: .9rem; font-weight: 600; }
+.lp-guide-ticker small { color: var(--lp-muted); font: 400 .75rem/1.45 var(--lp-mono); }
 
-.lp-guide-layout {
+/* Content layout */
+.lp-guide-content {
   width: min(1280px, calc(100% - 64px));
   margin-inline: auto;
-  display: flex;
-  gap: 48px;
-  padding: 48px 0;
-  position: relative;
+  display: grid;
+  grid-template-columns: 230px 1fr;
+  gap: 3rem;
+  padding-block: 3rem 5rem;
 }
 
+/* Sidebar */
 .lp-guide-sidebar {
-  width: 220px;
-  flex-shrink: 0;
-  position: sticky;
-  top: 88px;
-  align-self: flex-start;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
+  position: sticky; top: 100px; align-self: start;
 }
-
-.lp-guide-sidebar-link {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border: none;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--lp-muted);
-  font-size: .85rem;
-  font-weight: 500;
-  cursor: pointer;
-  text-align: left;
-  transition: all .15s ease;
-  font-family: inherit;
+.lp-guide-sidebar ol {
+  margin: 0; padding: 0; list-style: none;
+  border-left: 1px solid var(--lp-line);
 }
-
-.lp-guide-sidebar-link:hover { color: var(--lp-ink); background: var(--lp-accent-soft); }
-.lp-guide-sidebar-link.active { color: var(--lp-accent-strong); background: var(--lp-accent-soft); font-weight: 600; }
-
-.lp-guide-main {
-  flex: 1;
-  min-width: 0;
+.lp-guide-sidebar li { margin: 0; }
+.lp-guide-sidebar a {
+  display: flex; align-items: center; gap: .6rem;
+  min-height: 44px; padding: .45rem .75rem .45rem 1.2rem;
+  color: var(--lp-muted); font: 400 .78rem/1.35 var(--font-space-grotesk), sans-serif;
+  text-decoration: none;
+  border-left: 1px solid transparent;
+  margin-left: -1px;
+  transition: color .2s ease, border-color .2s ease;
 }
-
-.lp-guide-title {
-  font-size: 2rem;
-  font-weight: 700;
-  margin: 0 0 8px;
+.lp-guide-sidebar a:hover { color: var(--lp-ink); }
+.lp-guide-sidebar a.is-active {
   color: var(--lp-ink);
+  border-left-color: var(--lp-accent);
 }
+.lp-guide-sidebar-num { font: 500 .72rem/1 var(--lp-mono); color: var(--lp-accent); flex: 0 0 auto; }
+.lp-guide-sidebar a i { font-size: .75rem; width: 16px; text-align: center; flex: 0 0 auto; }
+.lp-guide-sidebar a span:last-child { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 
-.lp-guide-title i { color: var(--lp-accent); margin-right: 4px; }
-
-.lp-guide-intro {
-  font-size: 1rem;
-  line-height: 1.7;
-  color: var(--lp-body);
-  margin: 0 0 32px;
-  padding-bottom: 24px;
+/* Articles */
+.lp-guide-articles { min-width: 0; }
+.lp-guide-section {
+  scroll-margin-top: 100px;
+  padding-bottom: 3rem;
+  margin-bottom: 3rem;
   border-bottom: 1px solid var(--lp-line);
 }
-
-.lp-guide-steps {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
+.lp-guide-section:last-of-type { border-bottom: 0; }
+.lp-guide-section h2 {
+  margin: 0 0 1.2rem;
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+  font-weight: 520;
+  letter-spacing: -.03em;
+  line-height: 1.15;
 }
-
-.lp-guide-step {
-  padding: 20px 24px;
-  border-radius: 12px;
-  background: var(--lp-panel);
-  border: 1px solid var(--lp-line);
+.lp-guide-section h2 i { color: var(--lp-accent); margin-right: .5rem; font-size: .85em; }
+.lp-guide-section h3 {
+  margin: 2rem 0 1rem;
+  font-size: 1.15rem;
+  font-weight: 580;
 }
-
-.lp-guide-step-heading {
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--lp-ink);
-  margin: 0 0 8px;
-}
-
-.lp-guide-step p {
+.lp-guide-section p {
+  color: var(--lp-body);
   font-size: .92rem;
   line-height: 1.7;
+  margin: 0 0 1rem;
+}
+.lp-guide-section p code {
+  background: var(--lp-panel);
+  padding: .1em .35em;
+  border: 1px solid var(--lp-line);
+  font: 400 .82em/1.3 var(--lp-mono);
+}
+
+/* Code block */
+.lp-guide-code {
+  margin: 1.4rem 0;
+  border: 1px solid var(--lp-line-strong);
+  background: var(--lp-panel);
+  overflow-x: auto;
+}
+.lp-guide-code code {
+  display: block;
+  padding: 1.25rem 1.4rem;
+  font: 400 .82rem/1.6 var(--lp-mono);
   color: var(--lp-body);
+  white-space: pre;
+}
+
+/* Table */
+.lp-guide-table {
+  border-top: 1px solid var(--lp-line-strong);
+  margin: 1rem 0;
+}
+.lp-guide-tr {
+  display: grid;
+  grid-template-columns: 140px 1fr 80px 100px;
+  gap: 1rem;
+  align-items: center;
+  padding: .75rem 0;
+  border-bottom: 1px solid var(--lp-line);
+  font-size: .84rem;
+}
+.lp-guide-th {
+  font: 500 .72rem/1.55 var(--lp-mono);
+  color: var(--lp-muted);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.lp-guide-mono { font-family: var(--lp-mono); font-size: .78rem; color: var(--lp-accent); }
+/* Security mode table is 2-col */
+.lp-guide-section .lp-guide-table .lp-guide-th + .lp-guide-tr,
+.lp-guide-section .lp-guide-table .lp-guide-tr:nth-child(2) { grid-template-columns: 120px 1fr; }
+.lp-guide-section .lp-guide-table:has(.lp-guide-th:only-child) .lp-guide-tr { grid-template-columns: 120px 1fr; }
+
+/* Tip box */
+.lp-guide-tip {
+  display: flex;
+  gap: .7rem;
+  align-items: flex-start;
+  padding: .9rem 1.1rem;
+  margin: 1.4rem 0;
+  border: 1px solid rgba(145,160,255,.3);
+  background: var(--lp-accent-soft);
+}
+.lp-guide-tip i {
+  color: var(--lp-accent);
+  font-size: 1rem;
+  margin-top: .1rem;
+  flex: 0 0 auto;
+}
+.lp-guide-tip span {
+  color: var(--lp-body);
+  font-size: .85rem;
+  line-height: 1.6;
+}
+
+/* Article footer */
+.lp-guide-article-footer {
+  padding-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.2rem;
+}
+.lp-guide-article-footer p {
+  color: var(--lp-muted);
+  font-size: .84rem;
+  line-height: 1.6;
   margin: 0;
 }
 
-.lp-guide-step code {
-  padding: 2px 6px;
-  border-radius: 4px;
-  background: var(--lp-accent-soft);
-  color: var(--lp-accent-strong);
-  font-size: .88em;
-  font-family: var(--lp-mono);
-}
-
-.lp-guide-footer {
-  margin-top: 48px;
-  padding-top: 24px;
-  border-top: 1px solid var(--lp-line);
-  font-size: .85rem;
+/* Footer */
+.lp-guide-footer { border-top: 1px solid var(--lp-line); background: #07080b; }
+.lp-guide-footer-inner {
+  min-height: 100px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 2rem;
   color: var(--lp-muted);
+  font: 400 .75rem/1.4 var(--lp-mono);
+}
+.lp-guide-footer .lp-guide-logo { font-family: var(--font-space-grotesk); }
+.lp-guide-footer .lp-guide-logo-mark { width: 17px; height: 17px; }
+.lp-guide-footer a:last-child { color: var(--lp-body); text-decoration: none; }
+.lp-guide-footer a:last-child:hover { text-decoration: underline; }
+
+@keyframes lp-guide-enter { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: translateY(0); } }
+@keyframes lp-guide-status { 0%, 100% { opacity: .6; } 50% { opacity: 1; } }
+
+@media (max-width: 1050px) {
+  .lp-guide-shell,
+  .lp-guide-nav-inner,
+  .lp-guide-footer-inner { width: min(100% - 40px, 1280px); }
+  .lp-guide-content { width: min(100% - 40px, 1280px); grid-template-columns: 1fr; }
+  .lp-guide-sidebar { display: none; }
+  .lp-guide-nav-links { gap: .6rem; }
 }
 
-.lp-guide-footer a { color: var(--lp-accent); text-decoration: none; }
-.lp-guide-footer a:hover { text-decoration: underline; }
+@media (max-width: 700px) {
+  .lp-guide-shell,
+  .lp-guide-nav-inner,
+  .lp-guide-footer-inner,
+  .lp-guide-content { width: min(100% - 32px, 1280px); }
+  .lp-guide-nav-inner { min-height: 64px; }
+  .lp-guide-logo { font-size: .9rem; }
+  .lp-guide-logo-mark { width: 18px; height: 18px; }
+  .lp-guide-nav-links { display: none; }
+  .lp-guide-nav-actions { margin-left: auto; }
+  .lp-guide-lang { min-width: 68px; border: 0; padding: 0 .3rem; }
+  .lp-guide-hero .lp-guide-shell { min-height: auto; padding-block: 4rem; }
+  .lp-guide-hero h1 { font-size: clamp(2rem, 10vw, 2.8rem); }
+  .lp-guide-hero-actions { align-items: flex-start; flex-direction: column; gap: .7rem; }
+  .lp-guide-primary-cta { width: 100%; }
+  .lp-guide-secondary-cta { width: 100%; justify-content: center; }
+  .lp-guide-ticker-track { grid-template-columns: 1fr; }
+  .lp-guide-ticker p,
+  .lp-guide-ticker p:first-child { min-height: 82px; padding: 1rem 0; border-right: 0; border-bottom: 1px solid var(--lp-line); }
+  .lp-guide-ticker p:last-child { border-bottom: 0; }
+  .lp-guide-content { padding-block: 2rem 3rem; }
+  .lp-guide-tr { grid-template-columns: 1fr 1fr; gap: .3rem; }
+  .lp-guide-code code { padding: 1rem; font-size: .78rem; }
+  .lp-guide-footer-inner { min-height: 170px; flex-direction: column; justify-content: center; text-align: center; }
+}
+
+@media (max-width: 480px) {
+  .lp-guide-hero .lp-guide-shell { padding-block: 3rem; }
+  .lp-guide-hero h1 { font-size: clamp(1.8rem, 8vw, 2.4rem); }
+  .lp-guide-lede { font-size: .92rem; }
+  .lp-guide-section h2 { font-size: 1.7rem; }
+  .lp-guide-section h3 { font-size: 1rem; margin-top: 1.5rem; }
+  .lp-guide-section p { font-size: .86rem; }
+  .lp-guide-code code { padding: .85rem; font-size: .74rem; }
+  .lp-guide-tip { flex-direction: column; gap: .5rem; padding: .75rem .85rem; }
+  .lp-guide-tip span { font-size: .8rem; }
+  .lp-guide-article-footer p { font-size: .8rem; }
+}
+
+@media (max-width: 390px) {
+  .lp-guide-logo { gap: .5rem; letter-spacing: .12em; }
+  .lp-guide-lang { min-width: 62px; gap: .32rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html:has(.lp-guide) { scroll-behavior: auto; }
+  .lp-guide-hero .lp-guide-shell,
+  .lp-guide-live-dot { animation: none; }
+}

--- a/frontend/app/guide/page.js
+++ b/frontend/app/guide/page.js
@@ -5,381 +5,394 @@ import Link from 'next/link';
 import './guide.css';
 
 const SECTIONS = [
-  { id: 'architecture', icon: 'fa-sitemap', label_de: 'Architektur', label_en: 'Architecture' },
-  { id: 'getting-started', icon: 'fa-rocket', label_de: 'Erste Schritte', label_en: 'Getting Started' },
-  { id: 'ai-setup', icon: 'fa-brain', label_de: 'KI-Modelle', label_en: 'AI Models' },
-  { id: 'security', icon: 'fa-shield-halved', label_de: 'Sicherheit & Modi', label_en: 'Security & Modes' },
-  { id: 'nextcloud', icon: 'fa-cloud', label_de: 'Nextcloud', label_en: 'Nextcloud' },
-  { id: 'immich', icon: 'fa-images', label_de: 'Immich', label_en: 'Immich' },
-  { id: 'homeassistant', icon: 'fa-house-signal', label_de: 'Home Assistant', label_en: 'Home Assistant' },
-  { id: 'email', icon: 'fa-envelope', label_de: 'E-Mail', label_en: 'Email' },
-  { id: 'spotify', icon: 'fa-spotify', label_de: 'Spotify', label_en: 'Spotify' },
-  { id: 'discord', icon: 'fa-discord', label_de: 'Discord', label_en: 'Discord' },
-  { id: 'truenas', icon: 'fa-database', label_de: 'TrueNAS', label_en: 'TrueNAS' },
-  { id: 'browser', icon: 'fa-globe', label_de: 'Browser', label_en: 'Browser' },
+  { id: 'getting-started', icon: 'fa-rocket',
+    title_de: 'Erste Schritte', title_en: 'Getting Started',
+    desc_de: 'MYND in wenigen Minuten auf deiner eigenen Infrastruktur einrichten.', desc_en: 'Get MYND running on your own infrastructure in minutes.' },
+  { id: 'architecture', icon: 'fa-sitemap',
+    title_de: 'Architektur', title_en: 'Architecture',
+    desc_de: 'Wie MYND aufgebaut ist: Backend, Frontend, KI-Agent und Plugin-System.', desc_en: 'How MYND is built: backend, frontend, AI agent, and plugin system.' },
+  { id: 'ai-models', icon: 'fa-brain',
+    title_de: 'KI-Modelle', title_en: 'AI Models',
+    desc_de: 'Ollama oder OpenAI-kompatibel — welches Modell für deine Hardware und Anforderungen.', desc_en: 'Ollama or OpenAI-compatible — which model for your hardware and needs.' },
+  { id: 'security', icon: 'fa-shield-halved',
+    title_de: 'Sicherheit & Modi', title_en: 'Security & Modes',
+    desc_de: 'Sicherheitsmodi, Tool-Bestätigung, Berechtigungen und Datenschutz.', desc_en: 'Security modes, tool confirmation, permissions and privacy.' },
+  { id: 'nextcloud', icon: 'fa-cloud',
+    title_de: 'Nextcloud', title_en: 'Nextcloud',
+    desc_de: 'Dateien durchsuchen, Kalender und Aufgaben verwalten.', desc_en: 'Browse files, manage calendars and tasks.' },
+  { id: 'immich', icon: 'fa-images',
+    title_de: 'Immich', title_en: 'Immich',
+    desc_de: 'KI-gestützte Fotosuche in natürlicher Sprache.', desc_en: 'AI-powered photo search using natural language.' },
+  { id: 'homeassistant', icon: 'fa-house-signal',
+    title_de: 'Home Assistant', title_en: 'Home Assistant',
+    desc_de: 'Smart Home steuern — Sensoren, Geräte und Automationen.', desc_en: 'Control your smart home — sensors, devices, automations.' },
+  { id: 'email', icon: 'fa-envelope',
+    title_de: 'E-Mail', title_en: 'Email',
+    desc_de: 'Postfach verbinden, E-Mails suchen und senden.', desc_en: 'Connect your mailbox, search and send emails.' },
+  { id: 'spotify', icon: 'fa-spotify',
+    title_de: 'Spotify', title_en: 'Spotify',
+    desc_de: 'Wiedergabe steuern, Playlists verwalten.', desc_en: 'Control playback, manage playlists.' },
+  { id: 'discord', icon: 'fa-discord',
+    title_de: 'Discord', title_en: 'Discord',
+    desc_de: 'Nachrichten lesen, Kanäle durchsuchen.', desc_en: 'Read messages, search channels.' },
+  { id: 'truenas', icon: 'fa-database',
+    title_de: 'TrueNAS', title_en: 'TrueNAS',
+    desc_de: 'Speicher, Festplatten, SMART-Werte überwachen.', desc_en: 'Monitor storage, disks, SMART values.' },
+  { id: 'browser', icon: 'fa-globe',
+    title_de: 'Browser', title_en: 'Browser',
+    desc_de: 'Web-Recherche, Screenshots, Formulare.', desc_en: 'Web research, screenshots, forms.' },
 ];
-
-const GUIDE = {
-  'architecture': {
-    en: {
-      title: 'Architecture',
-      intro: 'MYND is a full-stack personal AI platform. Understanding the architecture helps you set it up correctly and get the most out of it.',
-      steps: [
-        { h: 'Overview', p: 'MYND consists of three main layers: a Python Flask backend (API server on port 5001), a Next.js frontend (web UI on port 3000), and a local AI model provider (Ollama or OpenAI-compatible API). All three can run on the same machine or be distributed across your network.' },
-        { h: 'Backend (Flask)', p: 'The backend at `app/routes.py` handles all API requests: authentication, AI model communication, plugin management, file storage, vault/credentials, and the agent loop that orchestrates multi-tool AI reasoning. Plugins in `data/plugins/` extend the backend with 25+ tools across 11 integrations.' },
-        { h: 'Frontend (Next.js)', p: 'The React-based UI at `frontend/` provides the chat interface, settings panels, plugin manager, and landing/marketing pages. It communicates with the backend via REST API calls and server-sent events (SSE) for real-time streaming of AI responses.' },
-        { h: 'AI Agent Loop', p: 'When you ask a question, MYND: (1) sends your prompt + available tool definitions to the AI model, (2) the model decides which tools to call and with what arguments, (3) MYND executes each tool and feeds results back to the model, (4) the model produces the final answer. This loop runs up to 100 rounds per query.' },
-        { h: 'Plugin System', p: 'Each integration (Nextcloud, Immich, etc.) is a self-contained plugin in `data/plugins/`. Plugins register tools with OpenAI-compatible function schemas. The system auto-discovers installed plugins at startup. You can write custom plugins in Python — see the Developers page.', tip: 'The system plugin (`system.py`) provides OS-level tools like timers, weather, web search, and disk monitoring — always available, no configuration needed.' },
-      ],
-    },
-    de: {
-      title: 'Architektur',
-      intro: 'MYND ist eine Full-Stack Personal-AI-Plattform. Das Verständnis der Architektur hilft bei der Einrichtung und optimalen Nutzung.',
-      steps: [
-        { h: 'Überblick', p: 'MYND besteht aus drei Hauptschichten: Einem Python Flask Backend (API-Server auf Port 5001), einem Next.js Frontend (Web-UI auf Port 3000) und einem lokalen KI-Modellanbieter (Ollama oder OpenAI-kompatibel). Alle drei können auf demselben Rechner oder verteilt laufen.' },
-        { h: 'Backend (Flask)', p: 'Das Backend in `app/routes.py` verarbeitet alle API-Anfragen: Authentifizierung, KI-Modell-Kommunikation, Plugin-Verwaltung, Dateispeicher, Tresor/Zugangsdaten und die Agenten-Schleife, die mehrstufige KI-Argumentation orchestriert. Plugins in `data/plugins/` erweitern das Backend um 25+ Tools in 11 Integrationen.' },
-        { h: 'Frontend (Next.js)', p: 'Die React-basierte UI in `frontend/` bietet die Chat-Oberfläche, Einstellungen, Plugin-Manager und Marketing-Seiten. Sie kommuniziert mit dem Backend über REST-API-Aufrufe und Server-Sent-Events (SSE) für Echtzeit-Streaming von KI-Antworten.' },
-        { h: 'KI-Agenten-Schleife', p: 'Wenn du eine Frage stellst, führt MYND folgende Schritte aus: (1) Prompt + verfügbare Tool-Definitionen an das KI-Modell senden, (2) das Modell entscheidet, welche Tools aufgerufen werden, (3) MYND führt jedes Tool aus und gibt die Ergebnisse zurück, (4) das Modell erzeugt die endgültige Antwort. Bis zu 100 Runden pro Anfrage.' },
-        { h: 'Plugin-System', p: 'Jede Integration ist ein eigenständiges Plugin in `data/plugins/`. Plugins registrieren Tools mit OpenAI-kompatiblen Funktionsschemata. Das System erkennt installierte Plugins automatisch beim Start. Du kannst eigene Plugins in Python schreiben — siehe Entwickler-Seite.', tip: 'Das System-Plugin (`system.py`) stellt Betriebssystem-Tools wie Timer, Wetter, Websuche und Festplatten-Überwachung bereit — immer verfügbar, keine Konfiguration nötig.' },
-      ],
-    },
-  },
-  'getting-started': {
-    en: {
-      title: 'Getting Started',
-      intro: 'Get MYND up and running on your own infrastructure in minutes. All steps work on Linux, macOS, and Windows.',
-      steps: [
-        { h: '1. Check system requirements', p: 'Python 3.10+, Node.js 18+, 4 GB RAM minimum (8+ GB recommended), 20+ GB free disk space. For local AI models, you need additional RAM: ~4 GB for small models (Phi, TinyLlama), ~8 GB for medium models (Llama 3.2, Mistral), ~16 GB for large models (Qwen 2.5, Llama 3.1).' },
-        { h: '2. Clone and install backend', p: 'Run these commands:\n\n```\ngit clone https://github.com/SchBenedikt/mynd.git\ncd mynd\npython -m venv .venv\nsource .venv/bin/activate  # Windows: .venv\\Scripts\\activate\npip install -r requirements.txt\n```\n\nThe backend dependencies include Flask, NumPy, requests, and Werkzeug — all standard Python libraries for web servers and data processing.' },
-        { h: '3. Start the backend', p: 'Run `python app.py` from the project root. Expected output: `Running on http://0.0.0.0:5001`. The first run creates a `config.yaml` automatically. The backend is now ready to receive API requests.', tip: 'Keep this terminal open. For production, use a process manager like supervisord or systemd.' },
-        { h: '4. Start the frontend', p: 'Open a second terminal, navigate to `frontend/`, and run:\n\n```\nnpm install\nnpm run dev\n```\n\nThe UI is available at http://localhost:3000. For production: `npm run build && npm start`. The dev mode supports hot-reload for development.' },
-        { h: '5. Set up AI and create account', p: 'Open http://localhost:3000, click "Sign in" → "Create account". After login, go to Settings → AI and configure your model provider (Ollama or OpenAI-compatible). Then go to Settings → Integrations to connect your services.' },
-      ],
-    },
-    de: {
-      title: 'Erste Schritte',
-      intro: 'MYND in wenigen Minuten auf deiner eigenen Infrastruktur einrichten.',
-      steps: [
-        { h: '1. Systemvoraussetzungen prüfen', p: 'Python 3.10+, Node.js 18+, mindestens 4 GB RAM (8+ GB empfohlen), 20+ GB freier Speicher. Für lokale KI-Modelle zusätzlicher RAM: ~4 GB für kleine Modelle (Phi, TinyLlama), ~8 GB für mittlere (Llama 3.2, Mistral), ~16 GB für große (Qwen 2.5, Llama 3.1).' },
-        { h: '2. Repository klonen und Backend installieren', p: 'Führe diese Befehle aus:\n\n```\ngit clone https://github.com/SchBenedikt/mynd.git\ncd mynd\npython -m venv .venv\nsource .venv/bin/activate\npip install -r requirements.txt\n```' },
-        { h: '3. Backend starten', p: 'Führe `python app.py` aus. Erwartete Ausgabe: `Running on http://0.0.0.0:5001`. Beim ersten Start wird automatisch eine `config.yaml` erstellt.', tip: 'Dieses Terminal geöffnet lassen. Für Produktivbetrieb einen Prozess-Manager wie systemd verwenden.' },
-        { h: '4. Frontend installieren und starten', p: 'Öffne ein zweites Terminal, wechsle in `frontend/` und führe aus:\n\n```\nnpm install\nnpm run dev\n```\n\nDie UI ist unter http://localhost:3000 erreichbar.' },
-        { h: '5. KI einrichten und Account erstellen', p: 'Öffne http://localhost:3000, klicke "Sign in" → "Create account". Gehe zu Settings → AI und konfiguriere den Modellanbieter. Danach unter Settings → Integrations die gewünschten Dienste verbinden.' },
-      ],
-    },
-  },
-  'ai-setup': {
-    en: {
-      title: 'AI Models',
-      intro: 'MYND works with any Ollama model or OpenAI-compatible API. Choosing the right model depends on your hardware and use case. Here is everything you need to know.',
-      steps: [
-        { h: '1. Install Ollama (recommended)', p: 'Ollama runs AI models locally on your hardware. Install it:\n\n- **Linux**: `curl -fsSL https://ollama.com/install.sh | sh`\n- **macOS**: Download from https://ollama.com\n- **Windows**: Download from https://ollama.com\n\nAfter installation, Ollama runs as a background service on port 11434. Verify with `curl http://127.0.0.1:11434/api/tags`.' },
-        { h: '2. Choose and pull a model', p: 'Your choice depends on your hardware and needs:\n\n**Hardware** | **Recommended Model** | **RAM** | **Tool Support**\n---|---|---|---\n8 GB RAM | `phi` (2.7 GB) | ~4 GB | Basic\n8 GB RAM | `tinyllama` (0.6 GB) | ~2 GB | No\n16 GB RAM | `llama3.2` (4.7 GB) | ~8 GB | Yes\n16 GB RAM | `mistral` (4.1 GB) | ~7 GB | Yes\n32 GB RAM | `qwen2.5` (4.9 GB) | ~9 GB | Excellent\n32 GB RAM | `llama3.1` (6.4 GB) | ~12 GB | Yes\n\nPull a model: `ollama pull llama3.2`', tip: 'For the best tool-use experience (required for integrations), choose a model with "Yes" or "Excellent" tool support. Models like `phi`, `gemma`, and `tinyllama` do NOT support tool calling.' },
-        { h: '3. Connect MYND to Ollama', p: 'Go to Settings → AI. Select "Ollama" as the provider. Enter `http://127.0.0.1:11434` (or your Ollama host). Click "Fetch Models" and select your downloaded model from the dropdown. Save the config.' },
-        { h: '4. OpenAI-compatible providers', p: 'MYND works with any OpenAI-compatible API. Supported providers include:\n\n- **OpenAI**: `https://api.openai.com/v1` (models: gpt-4o, gpt-4o-mini, o3-mini)\n- **Groq**: `https://api.groq.com/openai/v1` (models: llama-3.3-70b, mixtral-8x7b)\n- **Together**: `https://api.together.xyz/v1` (models: llama-3.3-70b, qwen-2.5-72b)\n- **Anthropic**: `https://api.anthropic.com/v1` (models: claude-3.5-sonnet)\n- **Google Gemini**: Via OpenAI-compatible proxy\n\nSelect "OpenAI Compatible" in Settings → AI, enter the Base URL and API key.', tip: 'Cloud models (OpenAI, Groq) are faster and more capable than local models but cost per request. Local models are free and private.' },
-        { h: '5. Test and verify', p: 'In Settings → AI, use "Test Connection" to verify the provider works. Use "Check Tool Support" to see which models support tool calling. A model without tool support can still answer questions but cannot access your integrations (Nextcloud, Immich, etc.).', tip: 'If a model fails tool support but you believe it should work, check your Ollama version (needs 0.3.0+ for tool calling).' },
-      ],
-    },
-    de: {
-      title: 'KI-Modelle',
-      intro: 'MYND funktioniert mit allen Ollama-Modellen und OpenAI-kompatiblen APIs. Die Wahl des richtigen Modells hängt von deiner Hardware und deinem Einsatzzweck ab.',
-      steps: [
-        { h: '1. Ollama installieren (empfohlen)', p: 'Ollama führt KI-Modelle lokal auf deiner Hardware aus. Installation:\n\n- **Linux**: `curl -fsSL https://ollama.com/install.sh | sh`\n- **macOS/Windows**: Download von https://ollama.com\n\nOllama läuft als Hintergrunddienst auf Port 11434. Prüfe mit `curl http://127.0.0.1:11434/api/tags`.' },
-        { h: '2. Modell auswählen und pullen', p: 'Die Wahl hängt von Hardware und Anforderungen ab:\n\n**Hardware** | **Empfohlenes Modell** | **RAM** | **Tool-Support**\n---|---|---|---\n8 GB RAM | `phi` (2.7 GB) | ~4 GB | Basis\n8 GB RAM | `tinyllama` (0.6 GB) | ~2 GB | Nein\n16 GB RAM | `llama3.2` (4.7 GB) | ~8 GB | Ja\n16 GB RAM | `mistral` (4.1 GB) | ~7 GB | Ja\n32 GB RAM | `qwen2.5` (4.9 GB) | ~9 GB | Hervorragend\n32 GB RAM | `llama3.1` (6.4 GB) | ~12 GB | Ja\n\nModell pullen: `ollama pull llama3.2`', tip: 'Für die Nutzung von Integrationen (Nextcloud, Immich etc.) ist Tool-Support erforderlich. Modelle wie `phi`, `gemma` und `tinyllama` unterstützen keine Tools.' },
-        { h: '3. MYND mit Ollama verbinden', p: 'Gehe zu Settings → AI. Wähle "Ollama" als Anbieter. Trage `http://127.0.0.1:11434` ein. Klicke "Fetch Models" und wähle dein Modell aus. Speichern.' },
-        { h: '4. OpenAI-kompatible Anbieter', p: 'MYND funktioniert mit allen OpenAI-kompatiblen APIs:\n\n- **OpenAI**: `https://api.openai.com/v1` (gpt-4o, gpt-4o-mini)\n- **Groq**: `https://api.groq.com/openai/v1` (llama-3.3-70b)\n- **Together**: `https://api.together.xyz/v1`\n\nWähle "OpenAI Compatible" in Settings → AI, trage Base-URL und API-Key ein.', tip: 'Cloud-Modelle sind schneller und leistungsfähiger als lokale, kosten aber pro Anfrage. Lokale Modelle sind kostenlos und privat.' },
-        { h: '5. Testen und prüfen', p: 'Nutze "Test Connection" in Settings → AI, um die Verbindung zu prüfen. "Check Tool Support" zeigt, welche Modelle Tool-Aufrufe unterstützen. Ein Modell ohne Tool-Support kann keine Integrationen nutzen.', tip: 'Ollama benötigt Version 0.3.0+ für Tool-Unterstützung.' },
-      ],
-    },
-  },
-  'security': {
-    en: {
-      title: 'Security & Modes',
-      intro: 'MYND offers multiple security layers and operating modes. Understanding these lets you balance convenience and safety.',
-      steps: [
-        { h: '1. Security Modes', p: 'Settings → AI → Security Mode controls which tools the AI can access:\n\n- **Restricted**: Only document search and memory. No external tools. Safest for untrusted environments.\n- **Standard** (default): Vault access + most tools, excluding SSH. Good balance of capability and safety.\n- **Admin**: Full access including SSH. All tools available, no confirmation prompts. Maximum capability.\n\nChange the mode at any time — it takes effect immediately.' },
-        { h: '2. Tool Confirmation System', p: 'In Standard and Restricted modes, certain tools require your confirmation before execution. These include: file operations (write, delete), email sending, home assistant state changes, SSH commands, and browser interactions. The confirmation dialog blocks execution until you approve or deny.', tip: 'In Admin mode, all tools run without confirmation. This is the "fully autonomous" mode described on the landing page.' },
-        { h: '3. Permission Mode (Bash/SSH)', p: 'Environment variable `MYND_PERMISSION_MODE` controls confirmation for bash and SSH commands:\n\n- **auto**: All commands allowed without confirmation\n- **semi**: Confirmation only for critical commands (rm, sudo, dd, mkfs, shutdown)\n- **ask**: Confirmation for every command (default)\n\nSet this in your `.env` file or export it before starting MYND.' },
-        { h: '4. Authentication', p: 'All API endpoints except login, registration, and health checks require authentication. Users can have role `user` or `admin`. Admin users can manage plugins, create/delete users, and reset the application. Registration can be enabled/disabled in Settings → Admin.', tip: 'Session tokens expire after 30 days of inactivity. Use Settings → Profile to change your password.' },
-        { h: '5. Data Privacy', p: 'All your data stays on your infrastructure. MYND never sends files or credentials to external servers (unless you configure an external AI provider). The cloud browser runs in a sandboxed environment on your server. Plugin state is stored locally in `plugin_state.json`.' },
-      ],
-    },
-    de: {
-      title: 'Sicherheit & Modi',
-      intro: 'MYND bietet mehrere Sicherheitsebenen und Betriebsmodi. Das Verständnis hilft dir, Komfort und Sicherheit optimal zu balancieren.',
-      steps: [
-        { h: '1. Sicherheitsmodi', p: 'Settings → AI → Security Mode kontrolliert, welche Tools die KI nutzen darf:\n\n- **Eingeschränkt**: Nur Dokumentsuche und Gedächtnis. Keine externen Tools.\n- **Standard** (Standard): Vault-Zugriff + die meisten Tools, außer SSH.\n- **Admin**: Voller Zugriff inkl. SSH. Alle Tools, keine Bestätigungsdialoge.' },
-        { h: '2. Tool-Bestätigung', p: 'Im Standard-Modus benötigen bestimmte Tools deine Bestätigung: Datei-Operationen, E-Mail-Versand, Home-Assistant-Schaltbefehle, Browser-Interaktionen. Der Bestätigungsdialog blockiert die Ausführung bis zur Freigabe.', tip: 'Im Admin-Modus laufen alle Tools ohne Bestätigung — der "vollautonome" Modus.' },
-        { h: '3. Berechtigungsmodus (Bash/SSH)', p: 'Die Umgebungsvariable `MYND_PERMISSION_MODE` steuert die Bestätigung für Bash- und SSH-Befehle:\n\n- **auto**: Alle Befehle erlaubt\n- **semi**: Nur bei kritischen Befehlen (rm, sudo, dd)\n- **ask**: Bei jedem Befehl (Standard)' },
-        { h: '4. Authentifizierung', p: 'Alle API-Endpunkte außer Login, Registrierung und Health-Check erfordern Authentifizierung. Benutzer haben die Rolle `user` oder `admin`. Admins verwalten Plugins, Benutzer und können die App zurücksetzen.' },
-        { h: '5. Datenschutz', p: 'Alle deine Daten bleiben auf deiner Infrastruktur. MYND sendet niemals Dateien oder Zugangsdaten an externe Server (außer bei Konfiguration eines externen KI-Anbieters).' },
-      ],
-    },
-  },
-  nextcloud: {
-    en: {
-      title: 'Nextcloud',
-      intro: 'Connect MYND to your Nextcloud instance to browse files, manage calendars and tasks, and search your cloud storage.',
-      steps: [
-        { h: '1. Create an app password', p: 'In Nextcloud, go to Settings → Security → "Create app password". Enter a name like "MYND" and copy the generated password. App passwords are preferred over your main password because they can be revoked individually.' },
-        { h: '2. Enter connection details in MYND', p: 'Go to Settings → Integrations → Nextcloud. Enter your Nextcloud URL (e.g. `https://nextcloud.example.com`), your username, and the app password. Click "Connect". MYND tests WebDAV and CalDAV connectivity.' },
-        { h: '3. Browse and search files', p: 'MYND accesses your files via WebDAV. Supported formats: PDF, TXT, DOCX, ODT, Markdown, JSON, YAML, XML, HTML, CSV, and source code files. Ask: "Search my Nextcloud for the budget spreadsheet" or "What documents were modified this week?"' },
-        { h: '4. Calendars and Tasks', p: 'Via CalDAV, MYND reads your calendars and task lists. Ask: "What appointments do I have tomorrow?", "Show my open tasks", "Create an event for Friday at 3 PM".', tip: 'Calendar events and tasks are read-only for safety. Use the Nextcloud UI for modifications, or ask MYND to draft the event details.' },
-        { h: '5. Example queries', p: '— "Search my Nextcloud for files containing invoice2025"\n— "Show me files shared with me"\n— "What changed in the Projects folder this week?"\n— "List my upcoming calendar events"\n— "Find the document tagged with important"', tip: 'The initial indexing scans recent files. For deeper searches across all files, allow a few minutes for full indexing.' },
-      ],
-    },
-    de: {
-      title: 'Nextcloud',
-      intro: 'Verbinde MYND mit deiner Nextcloud-Instanz für Dateisuche, Kalender- und Aufgabenverwaltung.',
-      steps: [
-        { h: '1. App-Passwort erstellen', p: 'In Nextcloud unter Einstellungen → Sicherheit → "App-Passwort erstellen". Namen wie "MYND" vergeben und das generierte Passwort kopieren.' },
-        { h: '2. Verbindung in MYND einrichten', p: 'Settings → Integrations → Nextcloud. URL (z.B. `https://nextcloud.example.com`), Benutzername und App-Passwort eintragen. "Connect" klicken.' },
-        { h: '3. Dateien durchsuchen', p: 'MYND greift über WebDAV auf Dateien zu. Unterstützte Formate: PDF, TXT, DOCX, ODT, Markdown, Code-Dateien. Frage: "Suche in Nextcloud nach der Budget-Tabelle".' },
-        { h: '4. Kalender und Aufgaben', p: 'Über CalDAV liest MYND Kalender und Aufgabenlisten. Frage: "Was habe ich morgen für Termine?", "Zeige meine offenen Aufgaben".', tip: 'Kalender und Aufgaben sind schreibgeschützt. Änderungen im Nextcloud-UI vornehmen.' },
-        { h: '5. Beispiel-Abfragen', p: '— "Suche in Nextcloud nach Rechnung 2025"\n— "Zeige meine geteilten Dateien"\n— "Was hat sich diese Woche im Projekte-Ordner geändert?"' },
-      ],
-    },
-  },
-  immich: {
-    en: {
-      title: 'Immich',
-      intro: 'Connect MYND to Immich for AI-powered photo search using natural language.',
-      steps: [
-        { h: '1. Create an API key', p: 'In Immich, go to Settings → Users → API Key. Create a new key named "MYND" and copy it. The key is shown only once.' },
-        { h: '2. Enter details in MYND', p: 'Settings → Integrations → Immich. Enter your Immich URL and the API key. Click "Connect". MYND will verify it can access your library.' },
-        { h: '3. Search your photos', p: 'MYND queries Immich\'s search API which automatically tags faces, objects, places, and scenes. Ask: "Show photos from last summer", "Find pictures with dogs", "What photos did I take in Paris?"' },
-        { h: '4. Filter by metadata', p: 'You can combine filters: camera model, date range, location, people, and objects. Ask: "Show photos from 2024 taken with my Sony camera", "Find pictures of Anna from the beach vacation".', tip: 'MYND searches metadata only — your original photos stay in Immich. No images are transferred to MYND.' },
-      ],
-    },
-    de: {
-      title: 'Immich',
-      intro: 'Verbinde MYND mit Immich für KI-gestützte Fotosuche in natürlicher Sprache.',
-      steps: [
-        { h: '1. API-Key erstellen', p: 'In Immich unter Settings → Users → API Key. Neuen Key mit Name "MYND" erstellen und kopieren.' },
-        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → Immich. URL und API-Key eintragen. "Connect" klicken.' },
-        { h: '3. Fotos durchsuchen', p: 'MYND nutzt die Immich-Suche mit automatischer Gesichts-, Objekt- und Ortserkennung. Frage: "Zeige Fotos vom letzten Sommer", "Finde Bilder mit Hunden".' },
-        { h: '4. Nach Metadaten filtern', p: 'Kombiniere Filter: Kameramodell, Datumsbereich, Ort, Personen. Frage: "Zeige Fotos von 2024 mit meiner Sony-Kamera".', tip: 'MYND durchsucht nur Metadaten — Originalfotos bleiben in Immich.' },
-      ],
-    },
-  },
-  homeassistant: {
-    en: {
-      title: 'Home Assistant',
-      intro: 'Control your smart home through MYND — check sensors, toggle devices, and trigger automations.',
-      steps: [
-        { h: '1. Create a Long-Lived Access Token', p: 'In Home Assistant, click your profile (bottom-left) → "Long-Lived Access Token". Create a token named "MYND" and copy it.' },
-        { h: '2. Enter details in MYND', p: 'Settings → Integrations → Home Assistant. Enter the URL (e.g. `http://homeassistant.local:8123`) and the token. Click "Connect".' },
-        { h: '3. Check states', p: 'MYND reads all entity states. Ask: "What is the temperature in the living room?", "Is the front door locked?", "What is the energy consumption today?"' },
-        { h: '4. Control devices', p: 'Toggle devices and set values. Ask: "Turn off all lights", "Set the thermostat to 21 degrees", "Activate the good night scene".', tip: 'In Standard mode, state-changing actions require your confirmation. Switch to Admin mode in Settings → AI for autonomous control.' },
-      ],
-    },
-    de: {
-      title: 'Home Assistant',
-      intro: 'Steuere dein Smart Home über MYND — Sensoren abfragen, Geräte schalten und Automationen auslösen.',
-      steps: [
-        { h: '1. Long-Lived Token erstellen', p: 'In Home Assistant Profil → "Langzeit-Zugriffstoken". Token mit Name "MYND" erstellen und kopieren.' },
-        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → Home Assistant. URL (z.B. `http://homeassistant.local:8123`) und Token eintragen.' },
-        { h: '3. Zustände abfragen', p: 'Frage: "Wie ist die Temperatur im Wohnzimmer?", "Ist die Haustür verriegelt?", "Wie hoch ist der Stromverbrauch heute?"' },
-        { h: '4. Geräte steuern', p: 'Frage: "Schalte alle Lichter aus", "Stelle den Thermostat auf 21 Grad", "Aktiviere die Gute-Nacht-Szene".', tip: 'Im Standard-Modus benötigen Schaltbefehle Bestätigung. Admin-Modus für autonome Steuerung.' },
-      ],
-    },
-  },
-  email: {
-    en: {
-      title: 'Email',
-      intro: 'Connect MYND to your mailbox via IMAP/SMTP — search, read, and send emails.',
-      steps: [
-        { h: '1. Prepare your credentials', p: 'You need IMAP/SMTP server addresses, ports, and credentials. Common providers:\n\n- **Gmail**: imap.gmail.com:993, smtp.gmail.com:587 (requires app password)\n- **Outlook**: outlook.office365.com:993, smtp.office365.com:587\n- **Custom**: Use your mail server addresses' },
-        { h: '2. Add account in MYND', p: 'Settings → Integrations → Email → "Add Account". Enter server details and credentials. MYND tests both IMAP (receiving) and SMTP (sending) connections.' },
-        { h: '3. Search and read', p: 'MYND indexes recent emails. Ask: "Show my unread emails", "Find the invoice from last month", "Summarize emails from [sender]"', tip: 'For Gmail, use an App Password (Settings → Security → App Passwords). Your regular password may not work with IMAP/SMTP.' },
-        { h: '4. Send emails', p: 'MYND can send emails on your behalf. Ask: "Send an email to john@example.com with subject Meeting and body: Let us meet at 3 PM tomorrow."' },
-      ],
-    },
-    de: {
-      title: 'E-Mail',
-      intro: 'Verbinde MYND mit deinem Postfach — E-Mails suchen, lesen und senden.',
-      steps: [
-        { h: '1. Zugangsdaten vorbereiten', p: 'IMAP/SMTP-Server, Ports und Anmeldedaten. Übliche Anbieter:\n\n- **Gmail**: imap.gmail.com:993, smtp.gmail.com:587 (App-Passwort nötig)\n- **Outlook**: outlook.office365.com:993, smtp.office365.com:587' },
-        { h: '2. Konto hinzufügen', p: 'Settings → Integrations → Email → "Add Account". Server-Daten eintragen. MYND testet IMAP und SMTP getrennt.' },
-        { h: '3. Suchen und lesen', p: 'Frage: "Zeige meine ungelesenen E-Mails", "Finde die Rechnung vom letzten Monat".', tip: 'Bei Gmail ein App-Passwort verwenden (Settings → Sicherheit → App-Passwörter).' },
-        { h: '4. E-Mails senden', p: 'Frage: "Sende eine E-Mail an max@example.com mit Betreff Besprechung und Inhalt: Treffen morgen um 15 Uhr."' },
-      ],
-    },
-  },
-  spotify: {
-    en: {
-      title: 'Spotify',
-      intro: 'Control Spotify playback through MYND — search, play, and manage playlists via the official Spotify Web API.',
-      steps: [
-        { h: '1. Create a Spotify app', p: 'Go to https://developer.spotify.com/dashboard → "Create App". Name it "MYND". Set the Redirect URI to `http://localhost:5001/callback/spotify`. Copy the Client ID and Client Secret.' },
-        { h: '2. Connect in MYND', p: 'Settings → Integrations → Spotify. Enter Client ID and Secret. Click "Connect" — you will be redirected to Spotify to authorize. MYND stores the refresh token for permanent access.' },
-        { h: '3. Control playback', p: 'Ask: "Play [song] by [artist]", "Pause", "Next track", "What is currently playing?", "Play my Discover Weekly playlist".', tip: 'Spotify Premium is required for playback control. The free tier only allows read access.' },
-        { h: '4. Manage playlists', p: 'Ask: "Create a playlist called Morning Vibes", "Add this song to my Favorites playlist".', tip: 'For production, update the Redirect URI to your actual domain in the Spotify Developer Dashboard.' },
-      ],
-    },
-    de: {
-      title: 'Spotify',
-      intro: 'Steuere Spotify über MYND — Titel suchen, abspielen und Playlists verwalten.',
-      steps: [
-        { h: '1. Spotify-App erstellen', p: 'https://developer.spotify.com/dashboard → "Create App". Name "MYND". Redirect-URI: `http://localhost:5001/callback/spotify`. Client-ID und Secret kopieren.' },
-        { h: '2. In MYND verbinden', p: 'Settings → Integrations → Spotify. Client-ID und Secret eintragen. "Connect" — du wirst zu Spotify weitergeleitet.' },
-        { h: '3. Wiedergabe steuern', p: 'Frage: "Spiele [Song] von [Künstler]", "Pausiere", "Nächster Titel", "Spiele meine Discover Weekly Playlist".', tip: 'Spotify Premium erforderlich für Wiedergabesteuerung.' },
-        { h: '4. Playlists verwalten', p: 'Frage: "Erstelle eine Playlist mit Namen", "Füge diesen Song zu meiner Favorites-Playlist hinzu".' },
-      ],
-    },
-  },
-  discord: {
-    en: {
-      title: 'Discord',
-      intro: 'Connect MYND to Discord — read messages, search channels, and send messages via a dedicated bot.',
-      steps: [
-        { h: '1. Create a Discord bot', p: 'Go to https://discord.com/developers/applications → "New Application" → "Bot" → "Add Bot". Copy the token. Enable "Message Content Intent" and "Server Members Intent".' },
-        { h: '2. Invite the bot', p: 'Go to "OAuth2" → "URL Generator". Select "bot" with permissions: Send Messages, Read Message History, View Channels, Read Messages. Open the URL and select your server.', tip: 'You need "Manage Server" permissions to invite the bot.' },
-        { h: '3. Enter token in MYND', p: 'Settings → Integrations → Discord. Enter the bot token. Click "Connect". MYND will list your servers and channels.' },
-        { h: '4. Use it', p: 'Ask: "What is new on the [server] server?", "Search Discord for the project link", "Send a message to #general: I will be there in 5 minutes".', tip: 'MYND cannot read DMs — only channels the bot is a member of.' },
-      ],
-    },
-    de: {
-      title: 'Discord',
-      intro: 'Verbinde MYND mit Discord — Nachrichten lesen, Kanäle durchsuchen und senden.',
-      steps: [
-        { h: '1. Discord-Bot erstellen', p: 'https://discord.com/developers/applications → "New Application" → "Bot" → "Add Bot". Token kopieren. "Message Content Intent" aktivieren.' },
-        { h: '2. Bot einladen', p: '"OAuth2" → "URL Generator". "bot" auswählen mit Berechtigungen: Send Messages, Read Message History, View Channels.', tip: '"Manage Server"-Rechte erforderlich.' },
-        { h: '3. Token eintragen', p: 'Settings → Integrations → Discord. Bot-Token eintragen. "Connect".' },
-        { h: '4. Nutzung', p: 'Frage: "Was gibt es Neues auf [Server]?", "Suche in Discord nach dem Projekt-Link".' },
-      ],
-    },
-  },
-  truenas: {
-    en: {
-      title: 'TrueNAS',
-      intro: 'Monitor your TrueNAS system — storage pools, disk health, SMART data, services, and alerts via the TrueNAS API.',
-      steps: [
-        { h: '1. Create an API key', p: 'In TrueNAS, go to Settings → API Keys → "Add". Name it "MYND" and copy the key. It is shown only once.' },
-        { h: '2. Enter details in MYND', p: 'Settings → Integrations → TrueNAS. Enter your TrueNAS URL (e.g. `http://truenas.local:8080`) and the API key. Click "Connect".' },
-        { h: '3. Check storage', p: 'Ask: "How is my storage pool doing?", "How much free space do I have?", "Show me all pools and their usage".' },
-        { h: '4. Monitor health', p: 'Ask: "Are there any disk alerts?", "Show SMART status of all drives", "What services are running?".', tip: 'SMART long tests can take hours. MYND reports the most recent test results.' },
-      ],
-    },
-    de: {
-      title: 'TrueNAS',
-      intro: 'Überwache dein TrueNAS-System — Speicherpools, Festplatten, SMART-Werte und Alarme.',
-      steps: [
-        { h: '1. API-Key erstellen', p: 'In TrueNAS unter Settings → API Keys → "Add". Namen "MYND" vergeben und Key kopieren.' },
-        { h: '2. Verbindung einrichten', p: 'Settings → Integrations → TrueNAS. URL (z.B. `http://truenas.local:8080`) und API-Key eintragen.' },
-        { h: '3. Speicher prüfen', p: 'Frage: "Wie ist der Stand meines Speicherpools?", "Wie viel Speicher ist noch frei?"' },
-        { h: '4. Gesundheit überwachen', p: 'Frage: "Gibt es Festplatten-Alarme?", "Zeige SMART-Status aller Festplatten".', tip: 'SMART-Tests können Stunden dauern. MYND zeigt die letzten Ergebnisse.' },
-      ],
-    },
-  },
-  browser: {
-    en: {
-      title: 'Browser',
-      intro: 'MYND includes a built-in cloud browser for web research — navigate pages, take screenshots, extract text, and interact with forms.',
-      steps: [
-        { h: '1. How it works', p: 'The cloud browser is a headless Chromium instance running on your server. It opens websites, executes JavaScript, and captures screenshots — completely isolated from your regular browser with separate cookies, sessions, and extensions.' },
-        { h: '2. Browse and capture', p: 'Ask: "Open [URL]", "Take a screenshot of [URL]", "Summarize the content of [URL]". The browser renders JavaScript-heavy pages (React, Vue SPAs) before capturing.' },
-        { h: '3. Extract and search', p: 'Ask: "Extract all links from [URL]", "Search the page for [keyword]", "What is the main content of this article?"' },
-        { h: '4. Interact and download', p: 'Ask: "Fill the search form with [query] on [URL]", "Click the login button", "Download the PDF from this page".', tip: 'Browser interactions (clicks, form fills) require confirmation in Standard mode. Switch to Admin mode for autonomous browsing.' },
-      ],
-    },
-    de: {
-      title: 'Browser',
-      intro: 'MYND enthält einen integrierten Cloud-Browser für Web-Recherche — navigieren, Screenshots machen, Texte extrahieren.',
-      steps: [
-        { h: '1. Funktionsweise', p: 'Der Cloud-Browser ist eine server-seitige, isolierte Chromium-Instanz. Keine Cookies oder Sitzungen werden mit deinem normalen Browser geteilt.' },
-        { h: '2. Navigieren und Screenshots', p: 'Frage: "Öffne [URL]", "Mach einen Screenshot von [URL]", "Fasse den Inhalt von [URL] zusammen".' },
-        { h: '3. Extrahieren und suchen', p: 'Frage: "Extrahiere alle Links von [URL]", "Suche auf der Seite nach [Suchbegriff]".' },
-        { h: '4. Interagieren und herunterladen', p: 'Frage: "Fülle das Suchformular auf [URL] mit [Suchbegriff]", "Lade das PDF herunter".', tip: 'Browser-Interaktionen benötigen Bestätigung im Standard-Modus.' },
-      ],
-    },
-  },
-};
 
 export default function GuidePage() {
   const [lang, setLang] = useState('en');
-  const [activeSection, setActiveSection] = useState('getting-started');
+  const [activeId, setActiveId] = useState('getting-started');
 
   useEffect(() => {
     const mode = (() => { try { return localStorage.getItem('darkMode') || 'light'; } catch { return 'light'; } })();
     document.documentElement.setAttribute('data-mode', mode);
+    const observer = new IntersectionObserver(
+      entries => { for (const e of entries) { if (e.isIntersecting) { setActiveId(e.target.id); break; } } },
+      { rootMargin: '-100px 0px -66% 0px' }
+    );
+    for (const s of SECTIONS) {
+      const el = document.getElementById(s.id);
+      if (el) observer.observe(el);
+    }
+    return () => observer.disconnect();
   }, []);
 
   const t = (de, en) => lang === 'de' ? de : en;
-  const content = GUIDE[activeSection]?.[lang] || GUIDE[activeSection]?.en;
 
   return (
     <div className="lp-guide" lang={lang}>
-      <nav className="lp-nav">
-        <div className="lp-nav-inner">
-          <Link href="/" className="lp-logo">
-            <span className="lp-logo-mark"><i /></span>
+      <nav className="lp-guide-nav">
+        <div className="lp-guide-nav-inner">
+          <Link href="/" className="lp-guide-logo">
+            <span className="lp-guide-logo-mark"><i /></span>
             <span>MYND</span>
           </Link>
-          <div className="lp-nav-links">
-            <Link href="/guide">{t('Anleitung', 'Guide')}</Link>
+          <div className="lp-guide-nav-links">
+            <Link href="/guide" className="is-active">{t('Anleitung', 'Guide')}</Link>
             <Link href="/developers">{t('Entwickler', 'Developers')}</Link>
           </div>
-          <div className="lp-nav-actions">
-            <button className="lp-language" type="button" onClick={() => setLang(l => l === 'de' ? 'en' : 'de')}>
+          <div className="lp-guide-nav-actions">
+            <button className="lp-guide-lang" type="button" onClick={() => setLang(l => l === 'de' ? 'en' : 'de')}>
               <span className={lang === 'de' ? 'active' : ''}>DE</span>
               <i />
               <span className={lang === 'en' ? 'active' : ''}>EN</span>
             </button>
-            <Link href="/login" className="lp-signin">
-              {t('Anmelden', 'Sign in')} <i className="fas fa-arrow-right" />
-            </Link>
           </div>
         </div>
       </nav>
 
-      <div className="lp-guide-layout lp-shell">
+      <section className="lp-guide-hero">
+        <div className="lp-guide-shell">
+          <p className="lp-guide-eyebrow">
+            <span className="lp-guide-live-dot" />
+            {t('Dokumentation', 'Documentation')}
+          </p>
+          <h1>{t('MYND einrichten & nutzen', 'Setting up & using MYND')}</h1>
+          <p className="lp-guide-lede">{t(
+            'Von der Installation über die KI-Konfiguration bis zu allen Integrationen — hier findest du Schritt-für-Schritt-Anleitungen.',
+            'From installation to AI configuration to all integrations — find step-by-step guides here.'
+          )}</p>
+          <div className="lp-guide-hero-actions">
+            <Link href="#getting-started" className="lp-guide-primary-cta">
+              <span>{t('Loslegen', 'Get started')}</span>
+              <i className="fas fa-arrow-down" />
+            </Link>
+            <Link href="/developers" className="lp-guide-secondary-cta">
+              <i className="fas fa-code" />
+              <span>{t('Plugin-Entwicklung', 'Plugin Development')}</span>
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <aside className="lp-guide-ticker" aria-label={t('Übersicht', 'Overview')}>
+        <div className="lp-guide-shell lp-guide-ticker-track">
+          <p><span>01</span><strong>{t('Lokal & privat', 'Local & private')}</strong><small>{t('Alles läuft auf deiner Infrastruktur', 'Everything runs on your infrastructure')}</small></p>
+          <p><span>02</span><strong>{t('Alle Dienste vernetzt', 'All services connected')}</strong><small>{t('Nextcloud, Home Assistant, Immich, E-Mail und mehr', 'Nextcloud, Home Assistant, Immich, Email and more')}</small></p>
+          <p><span>03</span><strong>{t('Volle Kontrolle', 'Full control')}</strong><small>{t('Sicherheitsmodi, Tool-Bestätigung, Admin-Rechte', 'Security modes, tool confirmation, admin privileges')}</small></p>
+        </div>
+      </aside>
+
+      <div className="lp-guide-content">
         <aside className="lp-guide-sidebar">
-          <nav aria-label={t('Navigation', 'Navigation')}>
-            {SECTIONS.map(s => (
-              <button
-                key={s.id}
-                className={`lp-guide-sidebar-link${activeSection === s.id ? ' active' : ''}`}
-                onClick={() => setActiveSection(s.id)}
-              >
-                <i className={`fas ${s.icon}`} />
-                {s[`label_${lang}`] || s.label_en}
-              </button>
-            ))}
+          <nav aria-label={t('Sektionen', 'Sections')}>
+            <ol>
+              {SECTIONS.map((s, i) => (
+                <li key={s.id}>
+                  <a href={`#${s.id}`} className={activeId === s.id ? 'is-active' : ''}
+                    onClick={(e) => { e.preventDefault(); document.getElementById(s.id)?.scrollIntoView({ behavior: 'smooth' }); setActiveId(s.id); }}>
+                    <span className="lp-guide-sidebar-num">{String(i + 1).padStart(2, '0')}</span>
+                    <i className={`fas ${s.icon}`} />
+                    <span>{s[`title_${lang}`]}</span>
+                  </a>
+                </li>
+              ))}
+            </ol>
           </nav>
         </aside>
 
-        <main className="lp-guide-main">
-          {content && (
-            <div className="lp-guide-section">
-              <h1 className="lp-guide-title">
-                <i className={`fas ${SECTIONS.find(s => s.id === activeSection)?.icon}`} />
-                {' '}{content.title}
-              </h1>
-              <p className="lp-guide-intro">{content.intro}</p>
-              <div className="lp-guide-steps">
-                {content.steps.map((step, i) => (
-                  <div key={i} className="lp-guide-step">
-                    <h2 className="lp-guide-step-heading">
-                      <span className="step-num">{String(i + 1).padStart(2, '0')}</span>
-                      {step.h.replace(/^\d+\.\s*/, '')}
-                    </h2>
-                    <p>{step.p}</p>
-                    {step.tip && <div className="lp-guide-tip"><strong>{t('Tipp', 'Tip')}:</strong> {step.tip}</div>}
-                  </div>
-                ))}
-              </div>
+        <div className="lp-guide-articles">
+          {/* Getting Started */}
+          <article className="lp-guide-section" id="getting-started">
+            <h2><i className="fas fa-rocket" /> {t('Erste Schritte', 'Getting Started')}</h2>
+            <p>{t(
+              'MYND ist deine lokale Personal-AI-Plattform. Stelle Fragen zu deinen Dateien, Geräten und Diensten — alles läuft auf deiner eigenen Infrastruktur.',
+              'MYND is your local personal AI platform. Ask questions about your files, devices and services — everything runs on your own infrastructure.'
+            )}</p>
+            <h3>{t('1. Systemvoraussetzungen', '1. System requirements')}</h3>
+            <p>{t('Python 3.10+, Node.js 18+, 4 GB RAM (8+ empfohlen), 20+ GB Speicher.', 'Python 3.10+, Node.js 18+, 4 GB RAM (8+ recommended), 20+ GB storage.')}</p>
+            <h3>{t('2. Backend installieren & starten', '2. Install & start the backend')}</h3>
+            <pre className="lp-guide-code"><code>{`git clone https://github.com/SchBenedikt/mynd.git
+cd mynd
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python app.py`}</code></pre>
+            <p>{t('Der Server läuft auf http://0.0.0.0:5001.', 'The server runs on http://0.0.0.0:5001.')}</p>
+            <h3>{t('3. Frontend starten', '3. Start the frontend')}</h3>
+            <pre className="lp-guide-code"><code>{`cd frontend
+npm install
+npm run dev`}</code></pre>
+            <p>{t('Die UI ist erreichbar unter http://localhost:3000.', 'The UI is at http://localhost:3000.')}</p>
+            <h3>{t('4. Account erstellen & KI konfigurieren', '4. Create account & configure AI')}</h3>
+            <p>{t(
+              'Öffne die UI, klicke "Sign in" → "Create account". Gehe zu Settings → AI und wähle deinen Modellanbieter (Ollama oder OpenAI-kompatibel). Danach unter Settings → Integrations die gewünschten Dienste verbinden.',
+              'Open the UI, click "Sign in" → "Create account". Go to Settings → AI and choose your model provider (Ollama or OpenAI-compatible). Then connect your services under Settings → Integrations.'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Für Produktivbetrieb: Nutze einen Reverse Proxy (nginx) und einen Prozess-Manager (systemd).', 'For production: Use a reverse proxy (nginx) and a process manager (systemd).')}</span></div>
+          </article>
+
+          {/* Architecture */}
+          <article className="lp-guide-section" id="architecture">
+            <h2><i className="fas fa-sitemap" /> {t('Architektur', 'Architecture')}</h2>
+            <p>{t(
+              'MYND besteht aus drei Schichten: einem Python-Flask-Backend (API, Port 5001), einem Next.js-Frontend (UI, Port 3000) und einem KI-Modellanbieter (Ollama oder OpenAI-kompatibel).',
+              'MYND consists of three layers: a Python Flask backend (API, port 5001), a Next.js frontend (UI, port 3000), and an AI model provider (Ollama or OpenAI-compatible).'
+            )}</p>
+            <h3>{t('Backend', 'Backend')}</h3>
+            <p>{t(
+              'Das Backend in app/routes.py verarbeitet API-Anfragen, Authentifizierung, KI-Kommunikation, Plugin-Verwaltung und die Agenten-Schleife. Plugins in data/plugins/ erweitern es um 25+ Tools in 11 Integrationen.',
+              'The backend in app/routes.py handles API requests, authentication, AI communication, plugin management, and the agent loop. Plugins in data/plugins/ extend it with 25+ tools across 11 integrations.'
+            )}</p>
+            <h3>{t('Frontend', 'Frontend')}</h3>
+            <p>{t(
+              'Die React-basierte UI bietet Chat, Einstellungen, Plugin-Manager und Marketing-Seiten. Sie kommuniziert per REST-API und SSE für Echtzeit-Streaming.',
+              'The React-based UI provides chat, settings, plugin manager, and marketing pages. It communicates via REST API and SSE for real-time streaming.'
+            )}</p>
+            <h3>{t('KI-Agenten-Schleife', 'AI Agent Loop')}</h3>
+            <p>{t(
+              'Bei einer Frage: (1) Prompt + Tool-Definitionen ans Modell senden, (2) Modell entscheidet über Tool-Aufrufe, (3) MYND führt Tools aus und gibt Ergebnisse zurück, (4) Modell erzeugt finale Antwort. Bis zu 100 Runden pro Anfrage.',
+              'When you ask: (1) send prompt + tool definitions to the model, (2) model decides tool calls, (3) MYND executes tools and returns results, (4) model produces final answer. Up to 100 rounds per query.'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Das System-Plugin (system.py) stellt Timer, Wetter, Websuche und Festplatten-Überwachung bereit — immer verfügbar, keine Konfiguration nötig.', 'The system plugin (system.py) provides timers, weather, web search, and disk monitoring — always available, no config needed.')}</span></div>
+          </article>
+
+          {/* AI Models */}
+          <article className="lp-guide-section" id="ai-models">
+            <h2><i className="fas fa-brain" /> {t('KI-Modelle', 'AI Models')}</h2>
+            <p>{t(
+              'MYND funktioniert mit Ollama (lokal) und allen OpenAI-kompatiblen APIs. Die Wahl des Modells bestimmt Geschwindigkeit, Qualität und ob Tool-Aufrufe möglich sind.',
+              'MYND works with Ollama (local) and all OpenAI-compatible APIs. Your model choice determines speed, quality, and whether tool calling is available.'
+            )}</p>
+            <h3>{t('Ollama installieren', 'Install Ollama')}</h3>
+            <pre className="lp-guide-code"><code>{`# Linux
+curl -fsSL https://ollama.com/install.sh | sh
+# macOS/Windows: Download von https://ollama.com`}</code></pre>
+            <h3>{t('Modell-Empfehlungen', 'Model recommendations')}</h3>
+            <div className="lp-guide-table">
+              <div className="lp-guide-tr lp-guide-th"><span>{t('Hardware', 'Hardware')}</span><span>{t('Modell', 'Model')}</span><span>{t('RAM', 'RAM')}</span><span>{t('Tool-Support', 'Tool Support')}</span></div>
+              <div className="lp-guide-tr"><span>8 GB</span><span className="lp-guide-mono">phi</span><span>~4 GB</span><span>{t('Basis', 'Basic')}</span></div>
+              <div className="lp-guide-tr"><span>8 GB</span><span className="lp-guide-mono">tinyllama</span><span>~2 GB</span><span>{t('Nein', 'No')}</span></div>
+              <div className="lp-guide-tr"><span>16 GB</span><span className="lp-guide-mono">llama3.2</span><span>~8 GB</span><span>{t('Ja', 'Yes')}</span></div>
+              <div className="lp-guide-tr"><span>16 GB</span><span className="lp-guide-mono">mistral</span><span>~7 GB</span><span>{t('Ja', 'Yes')}</span></div>
+              <div className="lp-guide-tr"><span>32 GB</span><span className="lp-guide-mono">qwen2.5</span><span>~9 GB</span><span>{t('Hervorragend', 'Excellent')}</span></div>
+              <div className="lp-guide-tr"><span>32 GB</span><span className="lp-guide-mono">llama3.1</span><span>~12 GB</span><span>{t('Ja', 'Yes')}</span></div>
             </div>
-          )}
-          <div className="lp-guide-footer">
-            <Link href="https://github.com/SchBenedikt/mynd" target="_blank">GitHub</Link>
-            {' · '}
-            <Link href="/developers">{t('Entwickler-Dokumentation', 'Developer Docs')}</Link>
-            {' · '}
-            <Link href="/login">{t('Zum Login', 'Go to Login')}</Link>
-          </div>
-        </main>
+            <h3>{t('OpenAI-kompatible Anbieter', 'OpenAI-compatible providers')}</h3>
+            <p>{t(
+              'Unterstützt werden OpenAI (gpt-4o, gpt-4o-mini), Groq (llama-3.3-70b), Together, Anthropic (claude-3.5) und Google Gemini. Konfiguriere Base-URL und API-Key in Settings → AI.',
+              'Supported: OpenAI (gpt-4o, gpt-4o-mini), Groq (llama-3.3-70b), Together, Anthropic (claude-3.5), and Google Gemini. Configure Base URL and API key in Settings → AI.'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Cloud-Modelle sind schneller, lokale Modelle sind kostenlos und privat. Für Tool-Support wird Ollama 0.3.0+ benötigt.', 'Cloud models are faster, local models are free and private. Tool support requires Ollama 0.3.0+.')}</span></div>
+          </article>
+
+          {/* Security & Modes */}
+          <article className="lp-guide-section" id="security">
+            <h2><i className="fas fa-shield-halved" /> {t('Sicherheit & Modi', 'Security & Modes')}</h2>
+            <p>{t(
+              'MYND bietet mehrere Sicherheitsebenen. Der richtige Modus balanciert Komfort und Sicherheit.',
+              'MYND offers multiple security layers. Choosing the right mode balances convenience and safety.'
+            )}</p>
+            <h3>{t('Sicherheitsmodi (Settings → AI)', 'Security Modes (Settings → AI)')}</h3>
+            <div className="lp-guide-table">
+              <div className="lp-guide-tr lp-guide-th"><span>{t('Modus', 'Mode')}</span><span>{t('Beschreibung', 'Description')}</span></div>
+              <div className="lp-guide-tr"><span className="lp-guide-mono">{t('Restricted', 'Restricted')}</span><span>{t('Nur Dokumentsuche + Gedächtnis. Keine externen Tools.', 'Only document search + memory. No external tools.')}</span></div>
+              <div className="lp-guide-tr"><span className="lp-guide-mono">{t('Standard', 'Standard')}</span><span>{t('Vault + Tools, kein SSH/Admin. Bestätigung bei kritischen Aktionen.', 'Vault + tools, no SSH/admin. Confirmation for critical actions.')}</span></div>
+              <div className="lp-guide-tr"><span className="lp-guide-mono">{t('Admin', 'Admin')}</span><span>{t('Voller Zugriff inkl. SSH. Keine Bestätigungsdialoge – vollautonom.', 'Full access including SSH. No confirmation dialogs – fully autonomous.')}</span></div>
+            </div>
+            <h3>{t('Tool-Bestätigung', 'Tool Confirmation')}</h3>
+            <p>{t(
+              'Im Standard-Modus benötigen bestimmte Tools deine Bestätigung: Datei-Operationen, E-Mail-Versand, Home-Assistant-Schaltbefehle, SSH-Kommandos, Browser-Interaktionen. Der Dialog blockiert die Ausführung bis zur Freigabe. Im Admin-Modus entfällt die Bestätigung.',
+              'In Standard mode, certain tools require confirmation: file operations, email sending, Home Assistant state changes, SSH commands, browser interactions. The dialog blocks execution until approved. In Admin mode, no confirmation is needed.'
+            )}</p>
+            <h3>{t('Berechtigungsmodus (Bash/SSH)', 'Permission Mode (Bash/SSH)')}</h3>
+            <p>{t(
+              'MYND_PERMISSION_MODE=auto (alle erlaubt) / semi (nur rm,sudo,dd) / ask (jeder Befehl). Setzbar in .env oder als Umgebungsvariable.',
+              'MYND_PERMISSION_MODE=auto (all allowed) / semi (only rm,sudo,dd) / ask (every command). Set in .env or as environment variable.'
+            )}</p>
+            <h3>{t('Authentifizierung', 'Authentication')}</h3>
+            <p>{t(
+              'API-Endpunkte benötigen Authentifizierung (außer Login/Register/Health). Rollen: user (eingeschränkt) und admin (volle Kontrolle). Admins können andere Admins erstellen, Plugins verwalten und die App zurücksetzen.',
+              'API endpoints require authentication (except login/register/health). Roles: user (restricted) and admin (full control). Admins can create other admins, manage plugins, and reset the app.'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Alle Daten bleiben auf deiner Infrastruktur. MYND sendet nichts an externe Server (außer deinem konfigurierten KI-Anbieter).', 'All data stays on your infrastructure. MYND sends nothing to external servers (except your configured AI provider).')}</span></div>
+          </article>
+
+          {/* Nextcloud */}
+          <article className="lp-guide-section" id="nextcloud">
+            <h2><i className="fas fa-cloud" /> {t('Nextcloud', 'Nextcloud')}</h2>
+            <p>{t('Verbinde MYND mit deiner Nextcloud, um Dateien zu durchsuchen, Kalender und Aufgaben abzurufen.', 'Connect MYND to your Nextcloud to browse files, fetch calendars and tasks.')}</p>
+            <h3>{t('1. App-Passwort erstellen', '1. Create app password')}</h3>
+            <p>{t('In Nextcloud: Einstellungen → Sicherheit → "App-Passwort erstellen". Namen "MYND" vergeben.', 'In Nextcloud: Settings → Security → "Create app password". Name it "MYND".')}</p>
+            <h3>{t('2. Verbindung einrichten', '2. Configure connection')}</h3>
+            <p>{t('Settings → Integrations → Nextcloud. URL, Benutzername und App-Passwort eintragen. "Connect" klicken.', 'Settings → Integrations → Nextcloud. Enter URL, username and app password. Click "Connect".')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Suche in Nextcloud nach der Budget-Tabelle", "Was gibt es Neues im Projekte-Ordner?", "Zeige meine Termine für morgen", "Erstelle einen Termin für Freitag 15 Uhr".',
+              'Ask: "Search my Nextcloud for the budget spreadsheet", "What is new in the Projects folder?", "Show my appointments for tomorrow", "Create an event for Friday 3 PM".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Unterstützte Formate: PDF, TXT, DOCX, ODT, Markdown, Code-Dateien. Kalender und Aufgaben sind lesend verfügbar.', 'Supported formats: PDF, TXT, DOCX, ODT, Markdown, code files. Calendars and tasks are read-only.')}</span></div>
+          </article>
+
+          {/* Immich */}
+          <article className="lp-guide-section" id="immich">
+            <h2><i className="fas fa-images" /> {t('Immich', 'Immich')}</h2>
+            <p>{t('KI-gestützte Fotosuche — durchsuche deine gesamte Bibliothek mit natürlicher Sprache.', 'AI-powered photo search — search your entire library with natural language.')}</p>
+            <h3>{t('1. API-Key erstellen', '1. Create API key')}</h3>
+            <p>{t('In Immich: Settings → Users → API Key. Namen "MYND" vergeben. Key wird nur einmal angezeigt.', 'In Immich: Settings → Users → API Key. Name it "MYND". Key shown once.')}</p>
+            <h3>{t('2. Verbinden', '2. Connect')}</h3>
+            <p>{t('Settings → Integrations → Immich. URL und API-Key eintragen. "Connect".', 'Settings → Integrations → Immich. Enter URL and API key. Click "Connect".')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Zeige Fotos vom letzten Sommer", "Finde Bilder mit Strand", "Welche Fotos habe ich in Paris gemacht?", "Finde Fotos von [Person]".',
+              'Ask: "Show photos from last summer", "Find pictures with beaches", "What photos did I take in Paris?", "Find photos of [person]".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('MYND durchsucht Metadaten — Originalfotos bleiben in Immich. Keine Bilder werden übertragen.', 'MYND searches metadata — original photos stay in Immich. No images are transferred.')}</span></div>
+          </article>
+
+          {/* Home Assistant */}
+          <article className="lp-guide-section" id="homeassistant">
+            <h2><i className="fas fa-house-signal" /> {t('Home Assistant', 'Home Assistant')}</h2>
+            <p>{t('Smart Home steuern — Sensoren abfragen, Geräte schalten, Automationen auslösen.', 'Control your smart home — query sensors, toggle devices, trigger automations.')}</p>
+            <h3>{t('1. Long-Lived Token erstellen', '1. Create Long-Lived Token')}</h3>
+            <p>{t('In Home Assistant: Profil (unten links) → "Langzeit-Zugriffstoken". Token erstellen und kopieren.', 'In Home Assistant: Profile (bottom left) → "Long-Lived Access Token". Create and copy.')}</p>
+            <h3>{t('2. Verbinden', '2. Connect')}</h3>
+            <p>{t('Settings → Integrations → Home Assistant. URL (z.B. http://homeassistant.local:8123) und Token eintragen.', 'Settings → Integrations → Home Assistant. Enter URL (e.g. http://homeassistant.local:8123) and token.')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Wie ist die Temperatur im Wohnzimmer?", "Schalte alle Lichter aus", "Ist die Haustür verriegelt?", "Starte die Guten-Morgen-Automation".',
+              'Ask: "What is the temperature in the living room?", "Turn off all lights", "Is the front door locked?", "Run the good morning automation".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Schaltbefehle benötigen Bestätigung im Standard-Modus. Admin-Modus für autonome Steuerung.', 'State changes require confirmation in Standard mode. Use Admin mode for autonomous control.')}</span></div>
+          </article>
+
+          {/* Email */}
+          <article className="lp-guide-section" id="email">
+            <h2><i className="fas fa-envelope" /> {t('E-Mail', 'Email')}</h2>
+            <p>{t('Postfach per IMAP/SMTP anbinden — E-Mails suchen, lesen und senden.', 'Connect mailbox via IMAP/SMTP — search, read and send emails.')}</p>
+            <h3>{t('1. Zugangsdaten', '1. Credentials')}</h3>
+            <p>{t('Du benötigst: IMAP-Server (Empfang), SMTP-Server (Versand), Benutzername und Passwort.', 'You need: IMAP server (receiving), SMTP server (sending), username and password.')}</p>
+            <h3>{t('2. Konto hinzufügen', '2. Add account')}</h3>
+            <p>{t('Settings → Integrations → Email → "Add Account". Server-Daten eintragen und verbinden.', 'Settings → Integrations → Email → "Add Account". Enter server details and connect.')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Zeige meine ungelesenen E-Mails", "Finde die Rechnung vom letzten Monat", "Sende eine E-Mail an max@example.com mit Betreff Meeting und Inhalt: Morgen 15 Uhr".',
+              'Ask: "Show my unread emails", "Find the invoice from last month", "Send an email to max@example.com with subject Meeting and body: Tomorrow 3 PM".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Bei Gmail ein App-Passwort verwenden (google.com/apppasswords).', 'For Gmail, use an app password (google.com/apppasswords).')}</span></div>
+          </article>
+
+          {/* Spotify */}
+          <article className="lp-guide-section" id="spotify">
+            <h2><i className="fas fa-spotify" /> {t('Spotify', 'Spotify')}</h2>
+            <p>{t('Wiedergabe steuern, Titel suchen und Playlists verwalten.', 'Control playback, search tracks and manage playlists.')}</p>
+            <h3>{t('1. Spotify-App erstellen', '1. Create Spotify app')}</h3>
+            <p>{t('https://developer.spotify.com/dashboard → "Create App". Redirect-URI: http://localhost:5001/callback/spotify. Client-ID und Secret kopieren.', 'https://developer.spotify.com/dashboard → "Create App". Redirect URI: http://localhost:5001/callback/spotify. Copy Client ID and Secret.')}</p>
+            <h3>{t('2. Verbinden', '2. Connect')}</h3>
+            <p>{t('Settings → Integrations → Spotify. Client-ID und Secret eintragen → "Connect".', 'Settings → Integrations → Spotify. Enter Client ID and Secret → "Connect".')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Spiele [Song] von [Künstler]", "Pausiere", "Nächster Titel", "Spiele meine Discover Weekly Playlist", "Erstelle eine Playlist mit Namen".',
+              'Ask: "Play [song] by [artist]", "Pause", "Next track", "Play my Discover Weekly playlist", "Create a playlist called".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Spotify Premium erforderlich für Wiedergabesteuerung. Für Produktivbetrieb Redirect-URI anpassen.', 'Spotify Premium required for playback control. Update Redirect URI for production.')}</span></div>
+          </article>
+
+          {/* Discord */}
+          <article className="lp-guide-section" id="discord">
+            <h2><i className="fas fa-discord" /> {t('Discord', 'Discord')}</h2>
+            <p>{t('Nachrichten lesen, Kanäle durchsuchen und Nachrichten senden.', 'Read messages, search channels and send messages.')}</p>
+            <h3>{t('1. Bot erstellen', '1. Create bot')}</h3>
+            <p>{t('https://discord.com/developers → "New Application" → "Bot". Token kopieren. "Message Content Intent" aktivieren.', 'https://discord.com/developers → "New Application" → "Bot". Copy token. Enable "Message Content Intent".')}</p>
+            <h3>{t('2. Bot einladen', '2. Invite bot')}</h3>
+            <p>{t('OAuth2 → URL Generator. "bot" mit Berechtigungen: Send Messages, Read Message History, View Channels.', 'OAuth2 → URL Generator. Select "bot" with permissions: Send Messages, Read Message History, View Channels.')}</p>
+            <h3>{t('3. Verbinden', '3. Connect')}</h3>
+            <p>{t('Settings → Integrations → Discord. Bot-Token eintragen. "Connect".', 'Settings → Integrations → Discord. Enter bot token. Click "Connect".')}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('MYND kann keine DMs lesen — nur Kanäle, in denen der Bot Mitglied ist.', 'MYND cannot read DMs — only channels the bot is a member of.')}</span></div>
+          </article>
+
+          {/* TrueNAS */}
+          <article className="lp-guide-section" id="truenas">
+            <h2><i className="fas fa-database" /> {t('TrueNAS', 'TrueNAS')}</h2>
+            <p>{t('Speicher, Festplatten und SMART-Werte über die TrueNAS-API überwachen.', 'Monitor storage, disks and SMART values via the TrueNAS API.')}</p>
+            <h3>{t('1. API-Key erstellen', '1. Create API key')}</h3>
+            <p>{t('In TrueNAS: Settings → API Keys → "Add". Namen "MYND" vergeben.', 'In TrueNAS: Settings → API Keys → "Add". Name it "MYND".')}</p>
+            <h3>{t('2. Verbinden', '2. Connect')}</h3>
+            <p>{t('Settings → Integrations → TrueNAS. URL (z.B. http://truenas.local:8080) und API-Key eintragen.', 'Settings → Integrations → TrueNAS. Enter URL (e.g. http://truenas.local:8080) and API key.')}</p>
+            <h3>{t('3. Nutzung', '3. Usage')}</h3>
+            <p>{t(
+              'Frage: "Wie ist der Speicherstatus?", "Wie voll ist der Hauptpool?", "Gibt es Festplatten-Alarme?", "Zeige SMART-Status aller Festplatten".',
+              'Ask: "What is the storage status?", "How full is the main pool?", "Are there any disk alerts?", "Show SMART status of all drives".'
+            )}</p>
+          </article>
+
+          {/* Browser */}
+          <article className="lp-guide-section" id="browser">
+            <h2><i className="fas fa-globe" /> {t('Browser', 'Browser')}</h2>
+            <p>{t('MYND enthält einen integrierten Cloud-Browser für Web-Recherche.', 'MYND includes a built-in cloud browser for web research.')}</p>
+            <h3>{t('Funktionsweise', 'How it works')}</h3>
+            <p>{t('Eine server-seitige, isolierte Chromium-Instanz. Keine Cookies oder Sitzungen werden mit deinem normalen Browser geteilt.', 'A server-side, isolated Chromium instance. No cookies or sessions shared with your regular browser.')}</p>
+            <h3>{t('Nutzung', 'Usage')}</h3>
+            <p>{t(
+              'Frage: "Öffne [URL]", "Mach einen Screenshot von [URL]", "Fasse den Inhalt von [URL] zusammen", "Suche auf der Seite nach [Suchbegriff]".',
+              'Ask: "Open [URL]", "Take a screenshot of [URL]", "Summarize the content of [URL]", "Search the page for [query]".'
+            )}</p>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Browser-Interaktionen (Klicks, Formulare) benötigen Bestätigung im Standard-Modus.', 'Browser interactions (clicks, forms) require confirmation in Standard mode.')}</span></div>
+          </article>
+
+          <footer className="lp-guide-article-footer">
+            <p>{t(
+              'Noch Fragen? Das Developer Portal und der Quellcode auf GitHub enthalten weitere Details.',
+              'Questions? The Developer Portal and source code on GitHub have more details.'
+            )}</p>
+            <Link href="/" className="lp-guide-primary-cta">
+              <i className="fas fa-arrow-left" />
+              {t('Zurück zur Startseite', 'Back to home')}
+            </Link>
+          </footer>
+        </div>
       </div>
+
+      <footer className="lp-guide-footer">
+        <div className="lp-guide-shell lp-guide-footer-inner">
+          <Link href="/" className="lp-guide-logo"><span className="lp-guide-logo-mark"><i /></span><span>MYND</span></Link>
+          <p>© {new Date().getFullYear()} MYND · {t('Setup-Anleitung', 'Setup guide')}</p>
+          <Link href="/developers">{t('Entwickler-Dokumentation', 'Developer Docs')}</Link>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/frontend/components/LandingPage.js
+++ b/frontend/components/LandingPage.js
@@ -159,7 +159,7 @@ const MODES = [
 ];
 
 export default function LandingPage() {
-  const [lang, setLang] = useState('de');
+  const [lang, setLang] = useState('en');
   const [active, setActive] = useState(0);
   const [expandedInt, setExpandedInt] = useState(null);
 
@@ -390,6 +390,42 @@ export default function LandingPage() {
                     </div>
                   </div>
                 )}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="lp-questions lp-section" id="questions">
+        <div className="lp-shell">
+          <header className="lp-section-header">
+            <div>
+              <p className="lp-kicker">{t('Beispielfragen', 'Example questions')}</p>
+              <h2>{t('Was du MYND fragen kannst.', 'What you can ask MYND.')}</h2>
+            </div>
+            <p>{t('Ob Alltag, Beruf oder Smart Home — MYND versteht dich und findet die passende Antwort in deinen Daten.', 'Whether daily life, work or smart home — MYND understands you and finds the right answer in your data.')}</p>
+          </header>
+          <div className="lp-question-list">
+            {[
+              { q_de: 'Wie ist die Temperatur im Wohnzimmer?', q_en: 'What\'s the temperature in the living room?', a_de: 'MYND fragt Home Assistant und zeigt den aktuellen Wert inkl. Luftfeuchtigkeit und Heizungsstatus.', a_en: 'MYND asks Home Assistant and shows the current value including humidity and heating status.' },
+              { q_de: 'Zeige Fotos von letztem Urlaub', q_en: 'Show photos from my last vacation', a_de: 'MYND sucht in Immich nach Aufnahmen aus dem Zeitraum und zeigt die Bilder mit Metadaten.', a_en: 'MYND searches Immich for photos from that period and shows them with metadata.' },
+              { q_de: 'Suche die Rechnung vom Januar', q_en: 'Find the January invoice', a_de: 'MYND durchsucht Nextcloud und E-Mails gleichzeitig nach dem Dokument.', a_en: 'MYND searches Nextcloud and emails simultaneously for the document.' },
+              { q_de: 'Fasse meine ungelesenen Mails zusammen', q_en: 'Summarize my unread emails', a_de: 'MYND ruft die neuesten Nachrichten per IMAP ab und erstellt eine Zusammenfassung.', a_en: 'MYND fetches the latest messages via IMAP and creates a summary.' },
+              { q_de: 'Spiele Musik zum Lernen', q_en: 'Play music for studying', a_de: 'MYND startet eine passende Spotify-Playlist auf deinem aktiven Gerät.', a_en: 'MYND starts a suitable Spotify playlist on your active device.' },
+              { q_de: 'Was lief heute im Discord?', q_en: 'What happened on Discord today?', a_de: 'MYND liest die neuesten Nachrichten aus deinen Discord-Kanälen.', a_en: 'MYND reads the latest messages from your Discord channels.' },
+              { q_de: 'Wie voll ist mein NAS?', q_en: 'How full is my NAS?', a_de: 'MYND fragt TrueNAS nach Speicherstatus und zeigt Pool-Auslastung.', a_en: 'MYND queries TrueNAS for storage status and shows pool utilization.' },
+              { q_de: 'Erstelle eine Zusammenfassung dieser Webseite', q_en: 'Summarize this webpage', a_de: 'MYND öffnet die URL im Cloud-Browser und extrahiert den Hauptinhalt.', a_en: 'MYND opens the URL in the cloud browser and extracts the main content.' },
+            ].map((item, i) => (
+              <article key={i} className="lp-question">
+                <div className="lp-question-number">{String(i + 1).padStart(2, '0')}</div>
+                <div className="lp-question-body">
+                  <h3>{t(item.q_de, item.q_en)}</h3>
+                  <p>{t(item.a_de, item.a_en)}</p>
+                </div>
+                <div className="lp-question-sources">
+                  <span className="lp-meta-label">{t('QUELLEN', 'SOURCES')}</span>
+                  <span className="lp-source-chip">{t('Live-Daten', 'Live data')}</span>
+                </div>
               </article>
             ))}
           </div>


### PR DESCRIPTION
- Guide page now uses same layout as /developers: hero section with CTA, ticker, sticky anchor-link sidebar, inline article sections with IntersectionObserver active tracking
- Added Architecture section (backend/frontend/agent loop/plugin system)
- Added Security & Modes section (security modes, tool confirmation, permissions, auth, privacy)
- Expanded AI Models section with hardware/RAM/tool-support comparison table
- All 12 integration sections with step-by-step instructions, code blocks, and tip boxes
- Landing page expanded with 'Example questions' section (8 use-case cards)
- Landing page default language is now English (useState('en'))
- Fixed unused variable lint error in guide/page.js