### PR TITLE
fix: remove gemma from NO_TOOL_MODEL_KEYWORDS (blocks default model), fix config path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,7 @@ MYND_VAULT_KEY=
 MYND_VAULT_KEY_FILE=
 
 # Models known to lack tool-calling support (comma-separated substrings)
-NO_TOOL_MODEL_KEYWORDS=gemma,phi,tinyllama
+NO_TOOL_MODEL_KEYWORDS=phi,tinyllama
 
 # OpenAI-compatible provider
 OPENAI_BASE_URL=

--- a/app/routes.py
+++ b/app/routes.py
@@ -458,7 +458,7 @@ def chat():
     system_prompt = _build_agent_system_prompt(message, language)
     cfg = load_ai_config()
     model_has_tools = check_tool_support(ollama_client.model, cfg.get('base_url'))
-    _ntk = [k.strip().lower() for k in os.getenv('NO_TOOL_MODEL_KEYWORDS', 'gemma,phi,tinyllama').split(',') if k.strip()]
+    _ntk = [k.strip().lower() for k in os.getenv('NO_TOOL_MODEL_KEYWORDS', 'phi,tinyllama').split(',') if k.strip()]
     if any(k in ollama_client.model.lower() for k in _ntk):
         model_has_tools = False
     no_tool_context = ""
@@ -567,7 +567,7 @@ def agent_query_stream():
     if cache_key not in agent_query_stream._tool_cache:
         agent_query_stream._tool_cache[cache_key] = check_tool_support(active_model, cfg.get('base_url'))
     model_has_tools = agent_query_stream._tool_cache[cache_key]
-    _ntk = [k.strip().lower() for k in os.getenv('NO_TOOL_MODEL_KEYWORDS', 'gemma,phi,tinyllama').split(',') if k.strip()]
+    _ntk = [k.strip().lower() for k in os.getenv('NO_TOOL_MODEL_KEYWORDS', 'phi,tinyllama').split(',') if k.strip()]
     if any(k in active_model.lower() for k in _ntk):
         model_has_tools = False
 

--- a/core/config.py
+++ b/core/config.py
@@ -12,7 +12,7 @@ EMBS = BASE / 'data' / 'embeddings.npy'
 VAULT_FILE = BASE / 'data' / 'vault.json'
 MEMORY_FILE = BASE / 'data' / 'memory.json'
 PLUGIN_DIR = BASE / 'data' / 'plugins'
-PLUGIN_STATE = BASE / 'data' / 'plugins_enabled.json'
+PLUGIN_STATE = BASE / 'data' / 'plugins' / 'plugin_state.json'
 
 OLLAMA = os.environ.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434").rstrip("/")
 

--- a/core/model.py
+++ b/core/model.py
@@ -12,7 +12,7 @@ if RICH:
 
 
 def _no_tool_keywords():
-    raw = os.getenv('NO_TOOL_MODEL_KEYWORDS', 'gemma,phi,tinyllama')
+    raw = os.getenv('NO_TOOL_MODEL_KEYWORDS', 'phi,tinyllama')
     return [k.strip().lower() for k in raw.split(',') if k.strip()]
 
 


### PR DESCRIPTION
## Bugs Fixed

1. **NO_TOOL_MODEL_KEYWORDS includes `gemma`** — The default model in `.env.example` is `gemma3:latest`, which contains the substring `gemma`. This caused tools to be silently disabled for anyone using the default config. Removed `gemma` from defaults in `.env.example`, `app/routes.py`, and `core/model.py`.

2. **core/config.py wrong path** — `PLUGIN_STATE = BASE / 'data' / 'plugins_enabled.json'` pointed to a non-existent file. The actual file is `data/plugins/plugin_state.json`. Fixed path. (Affects CLI `chat.py` only, not Flask app.)

## Files
- `.env.example` — removed gemma from NO_TOOL_MODEL_KEYWORDS
- `app/routes.py` — removed gemma from default (2 occurrences)
- `core/model.py` — removed gemma from default
- `core/config.py` — fixed path from `plugins_enabled.json` to `plugins/plugin_state.json`