### PR TITLE
Fix remaining bugs: exception leaks, upload limits, auth gaps, race conditions, hardcoded port

### DIFF
--- a/app/agent_loop.py
+++ b/app/agent_loop.py
@@ -1,5 +1,6 @@
 import json
 import re
+import threading
 import time
 from urllib.parse import urljoin, urlparse
 
@@ -19,6 +20,7 @@ PLUGIN_TOOLS = []
 PLUGIN_TOOL_MAP = {}
 AGENT_TOOLS = []
 WEB_TOOL_MAP = {}
+_web_tool_lock = threading.Lock()
 
 def load_plugins():
     global plugins_loaded, PLUGIN_TOOLS, PLUGIN_TOOL_MAP, AGENT_TOOLS, WEB_TOOL_MAP
@@ -28,8 +30,9 @@ def load_plugins():
     PLUGIN_TOOLS, PLUGIN_TOOL_MAP = _get_all_tools()
     AGENT_TOOLS = [*CORE_TOOLS, *PLUGIN_TOOLS]
     new_map = {**CORE_MAP, **PLUGIN_TOOL_MAP, 'prompt_user': web_prompt_user}
-    WEB_TOOL_MAP.clear()
-    WEB_TOOL_MAP.update(new_map)
+    with _web_tool_lock:
+        WEB_TOOL_MAP.clear()
+        WEB_TOOL_MAP.update(new_map)
     plugins_loaded = True
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,7 @@ GENERATED_DIR = DATA_DIR / 'generated'
 SETUP_DONE_FILE = DATA_DIR / 'setup_done.json'
 AUTH_CONFIG_FILE = DATA_DIR / 'auth_config.json'
 AUTH_FILE = DATA_DIR / 'auth_users.json'
+SERVER_PORT = int(os.getenv('MYND_PORT', '5001'))
 MEMORY_FILE = DATA_DIR / 'memory.json'
 VAULT_FILE = DATA_DIR / 'vault.json'
 API_REFS_PATH = DATA_DIR / 'api_refs.json'

--- a/app/routes.py
+++ b/app/routes.py
@@ -686,6 +686,7 @@ def agent_input():
 
 # ── /api/generated/* ───────────────────────────────────────
 @app.route('/api/generated/<path:filename>')
+@require_auth
 def serve_generated(filename):
     return send_from_directory(GENERATED_DIR, filename)
 
@@ -706,18 +707,25 @@ def upload_file():
     f = request.files['file']
     if f.filename == '':
         return jsonify({'success': False, 'error': 'No file selected'}), 400
+    _max_upload_size = 50 * 1024 * 1024
+    if request.content_length and request.content_length > _max_upload_size:
+        return jsonify({'success': False, 'error': 'File exceeds 50 MB limit'}), 400
     try:
         safe_name = re.sub(r'[^\w\.\-]', '_', f.filename)
         dest = os.path.realpath(os.path.join(UPLOAD_DIR, safe_name))
         if not dest.startswith(os.path.realpath(UPLOAD_DIR)):
             return jsonify({'success': False, 'error': 'Invalid path'}), 400
-        Path(dest).write_bytes(f.read())
+        data = f.read(_max_upload_size + 1)
+        if len(data) > _max_upload_size:
+            return jsonify({'success': False, 'error': 'File exceeds 50 MB limit'}), 400
+        Path(dest).write_bytes(data)
         size = os.path.getsize(dest)
         return jsonify({'success': True, 'filename': safe_name, 'size': size, 'url': f'/api/uploads/{safe_name}'})
     except Exception:
         return jsonify({'success': False, 'error': 'Upload failed'}), 500
 
 @app.route('/api/uploads/<path:filename>')
+@require_auth
 def serve_upload(filename):
     return send_from_directory(UPLOAD_DIR, filename)
 

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -41,7 +41,9 @@ def _start_indexing_scheduler():
         def auto_briefing():
             try:
                 import requests
-                requests.get("http://127.0.0.1:5001/api/agent/briefing", timeout=30)
+
+                from app.config import SERVER_PORT
+                requests.get(f"http://127.0.0.1:{SERVER_PORT}/api/agent/briefing", timeout=30)
             except Exception:
                 pass
 

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -38,8 +38,12 @@ def _load_json(path, default=None):
     return default if default is not None else []
 
 
+_scheduler_lock = threading.Lock()
+
+
 def _save_json(path, data):
-    path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding='utf-8')
+    with _scheduler_lock:
+        path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding='utf-8')
 
 
 def _validate_condition(condition: dict, context: dict) -> bool:

--- a/core/tools.py
+++ b/core/tools.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 import warnings
 from pathlib import Path
 
@@ -325,8 +326,9 @@ def search_documents(query, top_k=10):
                     f"[{chunks[i]['source']}] (Score: {scores[i]:.2f})\n{chunks[i]['text'][:300]}"
                 )
         return '\n\n---\n\n'.join(parts[:top_k]) if parts else "Keine Treffer."
-    except Exception as e:
-        return f"❌ {e}"
+    except Exception:
+        logger.exception("search_documents failed")
+        return "❌ Suche fehlgeschlagen"
 
 
 def _workspace_path(path):
@@ -478,7 +480,11 @@ def safe_http_request(method, url, *, headers=None, data=None, timeout=60, max_b
             raise ValueError(f'Response exceeds the {max_bytes}-byte limit')
         chunks = []
         total = 0
+        read_deadline = time.monotonic() + timeout
         for chunk in response.iter_content(chunk_size=16_384):
+            if time.monotonic() > read_deadline:
+                response.close()
+                raise ValueError('Response read timed out')
             total += len(chunk)
             if total > max_bytes:
                 response.close()


### PR DESCRIPTION
## Summary
Fixes 7 remaining issues identified in the audit.

### Changes

| Issue | Fix |
|-------|-----|
| #106 | `search_documents` logs exception instead of returning raw error to agent |
| #105 | `safe_http_request` adds monotonic read deadline (prevents indefinite streaming) |
| #99  | File upload enforces 50 MB limit via `content_length` + `f.read()` |
| #100 | `serve_generated` and `serve_upload` now require authentication |
| #103 | `auto_briefing` reads port from `MYND_PORT` env var (default 5001) |
| #104 | `_save_json` in scheduler uses `_scheduler_lock` for thread-safe writes |
| #101 | `WEB_TOOL_MAP` clear/update wrapped with `_web_tool_lock` |

### Files changed: `core/tools.py`, `core/scheduler.py`, `app/routes.py`, `app/scheduler.py`, `app/config.py`, `app/agent_loop.py`