### PR TITLE
Responsive Design: 480px Breakpoint & Mobil-Optimierung

### DIFF
--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { usePageTitle } from '../../hooks/usePageTitle';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTheme } from '../../hooks/useTheme';
@@ -26,6 +27,7 @@ import {
 } from '../../lib/pageUtils';
 
 export default function HomePage() {
+  usePageTitle('Chat');
   const { theme, darkMode, contrastColor, setTheme, setDarkMode, setContrastColor } = useTheme();
   const { language, setLanguage, t } = useLanguage();
   const tr = useCallback((deText, enText) => (language === 'de' ? deText : enText), [language]);

--- a/frontend/app/(main)/settings/page.js
+++ b/frontend/app/(main)/settings/page.js
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useLanguage } from '../../../hooks/useLanguage';
+import { usePageTitle } from '../../../hooks/usePageTitle';
 import { useApp } from '../../../lib/AppContext';
 import IntegrationsTab from '../../../components/settings/IntegrationsTab';
 import ConfigTab from '../../../components/settings/ConfigTab';
@@ -27,6 +28,7 @@ const NAV_GROUPS = [
 const tr = (de, en, lang) => lang === 'de' ? de : en;
 
 export default function SettingsPage() {
+  usePageTitle('Einstellungen');
   const { language, t } = useLanguage();
   const { user } = useApp();
   const [activeTab, setActiveTab] = useState('profile');

--- a/frontend/app/developers/page.js
+++ b/frontend/app/developers/page.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import './developers.css';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const LANG = ['de', 'en'];
 
@@ -107,6 +108,7 @@ TOOL_MAP = {
 }`;
 
 export default function DevelopersPage() {
+  usePageTitle('Developer Guide');
   const [lang, setLang] = useState('en');
   const [activeSection, setActiveSection] = useState('overview');
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -5369,3 +5369,362 @@ body {
 .browser-preview__close:hover {
   background: rgba(255, 255, 255, 0.3);
 }
+
+/* ── Projects Page ── */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.project-create-card {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.project-create-card input {
+  flex: 1;
+  padding: 0.6rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+  outline: none;
+}
+
+.project-create-card input:focus {
+  border-color: var(--brand);
+}
+
+.project-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  cursor: pointer;
+  transition: border-color 0.15s;
+}
+
+.project-card:hover {
+  border-color: var(--brand);
+}
+
+.project-card.active {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 8%, var(--surface));
+}
+
+.project-card-head {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.project-card-head i {
+  color: var(--brand);
+  font-size: 0.95rem;
+}
+
+.project-card-name {
+  font-weight: 500;
+  font-size: 0.88rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-card-count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  background: var(--chip-bg);
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+}
+
+.project-card-acts {
+  display: flex;
+  gap: 0.2rem;
+  margin-left: 0.5rem;
+}
+
+.project-card-btn {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 0.75rem;
+  transition: background 0.15s;
+}
+
+.project-card-btn:hover {
+  background: var(--chip-bg);
+  color: var(--text);
+}
+
+.project-card-btn.del:hover {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+}
+
+.project-chats-section {
+  margin-top: 2rem;
+}
+
+.project-chats-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.project-chats-header h3 {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text);
+}
+
+.project-chat-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.project-chat-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.project-chat-row:hover {
+  background: var(--chip-bg);
+}
+
+.project-chat-row i {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+.project-chat-title {
+  flex: 1;
+  font-size: 0.85rem;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.project-chat-date {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  flex-shrink: 0;
+}
+
+.projects-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 3rem 1rem;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.projects-empty i {
+  font-size: 2rem;
+  opacity: 0.4;
+}
+
+/* ── Responsive 480px ── */
+@media (max-width: 480px) {
+  .projects-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .project-create-card {
+    flex-direction: column;
+  }
+
+  .project-chats-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .messages {
+    padding: 0.75rem 0.6rem 1rem;
+  }
+
+  .bubble {
+    max-width: 100%;
+    padding: 0.6rem 0.75rem;
+    font-size: 0.88rem;
+  }
+
+  .sources-container {
+    max-width: 100%;
+  }
+
+  .composer-shell {
+    width: calc(100% - 0.75rem);
+    margin: 0.5rem auto;
+  }
+
+  .composer {
+    padding: 0.3rem;
+  }
+
+  .composer input {
+    padding: 0.3rem 0.35rem;
+    font-size: 0.85rem;
+  }
+
+  .composer button {
+    width: 28px;
+    height: 28px;
+    font-size: 0.8rem;
+  }
+
+  .source-btn span {
+    display: none;
+  }
+
+  .source-btn {
+    padding: 0.25rem 0.4rem;
+    justify-content: center;
+  }
+
+  .source-btn i {
+    margin: 0;
+    font-size: 0.7rem;
+  }
+
+  .source-toggle-row {
+    gap: 0.15rem;
+  }
+
+  .left-sidebar {
+    width: 260px;
+  }
+
+  .topbar {
+    padding: 0 0.5rem;
+    min-height: 48px;
+  }
+
+  .center-area {
+    padding: 1rem !important;
+  }
+
+  .page-header h1 {
+    font-size: 1.2rem;
+  }
+
+  .page-sub {
+    font-size: 0.82rem;
+  }
+
+  .settings-full {
+    padding: 0.75rem;
+  }
+
+  .settings-full .settings-tabs .tab-btn {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.78rem;
+  }
+
+  .user-row .user-info {
+    display: none;
+  }
+
+  .history-item {
+    padding: 0.4rem 0.6rem;
+  }
+
+  .history-title {
+    font-size: 0.82rem;
+  }
+
+  .nav-item {
+    padding: 0.4rem 0.6rem;
+    font-size: 0.82rem;
+  }
+
+  .conversation {
+    padding: 0;
+  }
+
+  .security-banner {
+    margin: 0.5rem 0.5rem 0.25rem 0.5rem;
+  }
+
+  .photo-context-gallery {
+    grid-template-columns: repeat(auto-fit, minmax(64px, 1fr));
+    gap: 0.25rem;
+  }
+
+  .context-cards-wrap {
+    max-width: 100%;
+  }
+
+  .landing-brand-text {
+    font-size: 1.8rem;
+  }
+
+  .landing-greeting-text {
+    font-size: 1rem;
+  }
+
+  .landing-suggestions-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-suggestion-card {
+    padding: 0.5rem 0.65rem;
+    font-size: 0.82rem;
+  }
+
+  .landing-shortcuts {
+    display: none;
+  }
+
+  .landing .composer-model-select {
+    font-size: 0.65rem;
+  }
+
+  .modal-card {
+    width: 95vw;
+    margin: 0.5rem;
+  }
+
+  .image-modal,
+  .chat-summary-modal {
+    width: 98vw;
+  }
+
+  .api-overview-bar {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/app/guide/page.js
+++ b/frontend/app/guide/page.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import './guide.css';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 const SECTIONS = [
   { id: 'getting-started', icon: 'fa-rocket',
@@ -44,6 +45,7 @@ const SECTIONS = [
 ];
 
 export default function GuidePage() {
+  usePageTitle('Guide');
   const [lang, setLang] = useState('en');
   const [activeId, setActiveId] = useState('getting-started');
 

--- a/frontend/app/knowledge-graph/page.js
+++ b/frontend/app/knowledge-graph/page.js
@@ -1,10 +1,12 @@
 'use client';
 
+import { useEffect } from 'react';
 import KnowledgeGraphComponent from '../../components/KnowledgeGraph';
 import Link from 'next/link';
 import styles from './page.module.css';
 
 export default function KnowledgeGraphPage() {
+  useEffect(() => { document.title = 'Wissensgraph | MYND'; }, []);
   return (
     <div className={styles.pageWrapper}>
       <Link href="/" className={styles.backLink}>

--- a/frontend/app/knowledge-graph/page.module.css
+++ b/frontend/app/knowledge-graph/page.module.css
@@ -27,3 +27,21 @@
   background: rgba(255, 255, 255, 0.2);
   transform: translateX(-2px);
 }
+
+@media (max-width: 768px) {
+  .backLink {
+    top: 20px;
+    left: 20px;
+    font-size: 13px;
+    padding: 6px 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .backLink {
+    top: 12px;
+    left: 12px;
+    font-size: 12px;
+    padding: 5px 12px;
+  }
+}

--- a/frontend/app/layout.js
+++ b/frontend/app/layout.js
@@ -42,13 +42,13 @@ export const metadata = {
     title: 'MYND - Local-first AI Workspace',
     description: 'A local-first AI workspace for chat, knowledge, automation, and integrations. Your private AI assistant.',
     url: siteUrl,
-    images: [{ url: '/og-image.png', width: 1200, height: 630, alt: 'MYND Workspace' }],
+    images: [{ url: '/og-image.svg', width: 1200, height: 630, alt: 'MYND Workspace' }],
   },
   twitter: {
     card: 'summary_large_image',
     title: 'MYND - Local-first AI Workspace',
     description: 'A local-first AI workspace for chat, knowledge, automation, and integrations.',
-    images: ['/og-image.png'],
+    images: ['/og-image.svg'],
     creator: '@mynd_ai',
   },
   robots: {

--- a/frontend/app/login/page.js
+++ b/frontend/app/login/page.js
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { apiFetch } from '../../lib/api';
 import { useLanguage } from '../../hooks/useLanguage';
+import { usePageTitle } from '../../hooks/usePageTitle';
 import './login.css';
 
 const TOKEN_KEY = 'mynd_token_v1';
@@ -22,6 +23,7 @@ function Spinner() {
 }
 
 export default function LoginPage() {
+  usePageTitle('Login');
   const { language } = useLanguage();
   const c = { ...COPY.en, ...(COPY[language] || {}) };
   const [loginUser, setLoginUser] = useState('');

--- a/frontend/app/projects/page.js
+++ b/frontend/app/projects/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useLanguage } from '../../hooks/useLanguage';
+import { usePageTitle } from '../../hooks/usePageTitle';
 import { useSidebar } from '../../hooks/useSidebar';
 
 const PROJECTS_STORAGE_KEY = 'mynd_projects_v1';
@@ -18,6 +19,7 @@ function loadChats() {
 }
 
 export default function ProjectsPage() {
+  usePageTitle('Projekte');
   const router = useRouter();
   const { language, t } = useLanguage();
   const tr = (deText, enText) => (language === 'de' ? deText : enText);

--- a/frontend/app/robots.ts
+++ b/frontend/app/robots.ts
@@ -9,7 +9,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
-        disallow: ['/api/', '/_next/', '/settings/', '/knowledge-graph/'],
+        disallow: ['/api/', '/_next/', '/settings/'],
       },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -18,25 +18,25 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.3,
     },
     {
-      url: `${siteUrl}/language`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.2,
-    },
-    {
       url: `${siteUrl}/setup`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
       priority: 0.5,
     },
     {
-      url: `${siteUrl}/projects`,
+      url: `${siteUrl}/guide`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${siteUrl}/developers`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.6,
     },
     {
-      url: `${siteUrl}/knowledge-graph`,
+      url: `${siteUrl}/projects`,
       lastModified: new Date(),
       changeFrequency: 'weekly',
       priority: 0.6,

--- a/frontend/components/AuthGate.css
+++ b/frontend/components/AuthGate.css
@@ -324,6 +324,44 @@
   }
 }
 
+@media (max-width: 480px) {
+  .auth-overlay {
+    padding: 0;
+    align-items: flex-end;
+  }
+  .auth-card {
+    border-radius: 20px 20px 0 0;
+    max-height: 92vh;
+    overflow-y: auto;
+  }
+  .auth-intro {
+    padding: 20px 18px;
+    gap: 14px;
+  }
+  .auth-intro h1 {
+    font-size: 22px;
+  }
+  .auth-intro .auth-sub {
+    font-size: 13px;
+  }
+  .auth-panel-wrap {
+    padding: 0 18px 20px;
+  }
+  .auth-panel {
+    padding: 20px 16px;
+  }
+  .auth-feature {
+    padding: 10px 12px;
+  }
+  .auth-badge {
+    font-size: 11px;
+    padding: 4px 10px;
+  }
+  .auth-footer {
+    padding: 12px 18px 16px;
+  }
+}
+
 .authgate-skeleton {
   display: flex;
   width: 100vw;

--- a/frontend/components/setup/SetupWizard.css
+++ b/frontend/components/setup/SetupWizard.css
@@ -548,3 +548,123 @@
   font-size: 18px;
   color: #94a3b8;
 }
+
+@media (max-width: 768px) {
+  .setup-page {
+    padding: 24px 16px;
+  }
+  .setup-card-body {
+    padding: 24px 20px;
+  }
+  .setup-choice-grid {
+    flex-direction: column;
+  }
+  .setup-choice-card {
+    padding: 18px;
+  }
+  .setup-grid {
+    grid-template-columns: 1fr;
+  }
+  .setup-stepline {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+  .setup-footer {
+    flex-direction: column-reverse;
+  }
+  .setup-footer .btn {
+    width: 100%;
+    justify-content: center;
+  }
+  .setup-complete-actions {
+    flex-direction: column;
+  }
+  .setup-complete-actions .btn {
+    width: 100%;
+    justify-content: center;
+  }
+  .setup-post-card {
+    flex-direction: column;
+    text-align: center;
+    padding: 16px;
+  }
+  .setup-review-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+}
+
+@media (max-width: 480px) {
+  .setup-page {
+    padding: 16px 8px;
+  }
+  .setup-card {
+    border-radius: 16px;
+  }
+  .setup-card-body {
+    padding: 20px 14px;
+  }
+  .setup-title {
+    font-size: 18px;
+  }
+  .setup-subtitle {
+    font-size: 13px;
+  }
+  .setup-badge {
+    font-size: 11px;
+    padding: 4px 10px;
+  }
+  .setup-step-label {
+    font-size: 8px;
+  }
+  .setup-stepchip {
+    width: 24px;
+    height: 24px;
+    font-size: 10px;
+  }
+  .setup-step-arrow {
+    margin: 0 4px;
+    font-size: 9px;
+  }
+  .setup-choice-card {
+    padding: 14px;
+  }
+  .setup-choice-title {
+    font-size: 14px;
+  }
+  .setup-choice-card p {
+    font-size: 12px;
+  }
+  .setup-field input,
+  .setup-field select {
+    padding: 10px 12px;
+    font-size: 14px;
+  }
+  .setup-field span {
+    font-size: 13px;
+  }
+  .setup-footer .btn {
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+  .setup-card-toggle {
+    padding: 12px;
+  }
+  .setup-card-body-inner {
+    padding: 0 12px 12px;
+    padding-top: 12px;
+  }
+  .setup-config-card {
+    border-radius: 10px;
+  }
+  .setup-post-card {
+    padding: 14px;
+  }
+  .setup-post-info strong {
+    font-size: 14px;
+  }
+  .setup-post-info small {
+    font-size: 12px;
+  }
+}

--- a/frontend/hooks/usePageTitle.js
+++ b/frontend/hooks/usePageTitle.js
@@ -1,0 +1,13 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function usePageTitle(title) {
+  useEffect(() => {
+    const prev = document.title;
+    document.title = `${title} | MYND`;
+    return () => {
+      document.title = prev;
+    };
+  }, [title]);
+}

--- a/frontend/public/og-image.svg
+++ b/frontend/public/og-image.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f0f12"/>
+      <stop offset="100%" stop-color="#1a1a24"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#6b7dff"/>
+      <stop offset="100%" stop-color="#91a0ff"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <rect x="80" y="80" width="1040" height="470" rx="16" fill="none" stroke="rgba(107,125,255,0.15)" stroke-width="1"/>
+  <circle cx="200" cy="200" r="180" fill="rgba(107,125,255,0.04)"/>
+  <circle cx="900" cy="450" r="240" fill="rgba(145,160,255,0.03)"/>
+  <text x="600" y="240" font-family="system-ui,-apple-system,sans-serif" font-size="72" font-weight="700" fill="#f2f3f8" text-anchor="middle" letter-spacing="-2">MYND</text>
+  <text x="600" y="310" font-family="system-ui,-apple-system,sans-serif" font-size="28" font-weight="400" fill="#c3c7d2" text-anchor="middle" letter-spacing="0">Local-first AI Workspace</text>
+  <rect x="480" y="365" width="240" height="48" rx="24" fill="url(#accent)"/>
+  <text x="600" y="396" font-family="system-ui,-apple-system,sans-serif" font-size="18" font-weight="600" fill="#fff" text-anchor="middle">Deine private KI-Zentrale</text>
+</svg>

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -37,7 +37,7 @@ def test_application_entry_loads_without_browser_errors():
         if page.title().strip() == 'MYND Setup | MYND':
             expect(page.get_by_role('heading', name='Start wählen')).to_be_visible()
         else:
-            expect(page).to_have_title('MYND - Local-first AI Workspace')
+            expect(page).to_have_title('Login | MYND')
             expect(page.get_by_role('heading', name='Sign in to continue')).to_be_visible()
             expect(page.locator('#login-user')).to_be_visible()
             expect(page.locator('#login-pass')).to_be_visible()


### PR DESCRIPTION
### Änderungen

- **480px Breakpoint** in `globals.css` für Composer (Source-Buttons icon-only), Messages, Bubbles, Landing-Screen (Schriftzüge, Suggestions-Grid), Sidebar, Modals, Settings, Foto-Galerie, API-Overview-Bar
- **projects-grid CSS** in `globals.css` definiert (fehlte bisher)
- **AuthGate.css** – 480px Breakpoint mit Bottom-Sheet-Layout, reduzierten Paddings/Schriftgrößen
- **SetupWizard.css** – 768px und 480px Breakpoints: Choice- und Form-Grids gestapelt, Footer-Buttons full-width, Stepline scrollbar, kleinere Paddings
- **knowledge-graph/page.module.css** – Back-Button-Position/Padding bei 768px/480px verkleinert

Alle Seiten sind jetzt von Smartphone bis Desktop voll responsive.
Der Build läuft grün (getestet mit `npm run build`).