### PR TITLE
ChatGPT (OpenAI OAuth) Integration

### DIFF
--- a/app/ollama_client.py
+++ b/app/ollama_client.py
@@ -85,6 +85,9 @@ class OllamaClient:
 ollama_client = OllamaClient()
 
 
+OAUTH_PROXY_URL = 'http://127.0.0.1:10531'
+
+
 def load_ai_config():
     cfg = {
         'provider': 'ollama',
@@ -109,10 +112,14 @@ def load_ai_config():
             pass
     if cfg['provider'] == 'ollama':
         ollama_client.update_config(cfg['base_url'], cfg['model'])
+    elif cfg['provider'] == 'openai-oauth':
+        cfg['base_url'] = OAUTH_PROXY_URL
     return cfg
 
 
 def save_ai_config(provider, base_url, model, api_key='', embedding_model=None):
+    if provider == 'openai-oauth':
+        base_url = OAUTH_PROXY_URL
     cfg = {
         'provider': provider or 'ollama',
         'base_url': base_url.rstrip('/'),
@@ -128,6 +135,49 @@ def save_ai_config(provider, base_url, model, api_key='', embedding_model=None):
     AI_CONFIG_FILE.write_text(json.dumps(display_cfg, indent=2, ensure_ascii=False))
     if cfg['provider'] == 'ollama':
         ollama_client.update_config(cfg['base_url'], cfg['model'])
+
+
+def check_oauth_proxy():
+    try:
+        r = requests.get(f'{OAUTH_PROXY_URL}/v1/models', timeout=3)
+        return r.status_code == 200
+    except Exception:
+        return False
+
+
+def fetch_oauth_models():
+    try:
+        r = requests.get(f'{OAUTH_PROXY_URL}/v1/models', timeout=5)
+        r.raise_for_status()
+        return [m['id'] for m in r.json().get('data', [])]
+    except Exception:
+        return []
+
+
+def check_oauth_auth():
+    auth_file = Path(os.path.expanduser('~/.codex/auth.json'))
+    return auth_file.exists()
+
+
+def start_oauth_proxy():
+    import subprocess
+    try:
+        subprocess.Popen(
+            ['npx', 'openai-oauth', '--detach', '-p', '10531'],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+        return True
+    except Exception as e:
+        return str(e)
+
+
+def stop_oauth_proxy():
+    import subprocess
+    try:
+        subprocess.run(['pkill', '-f', 'openai-oauth'], capture_output=True)
+        return True
+    except Exception as e:
+        return str(e)
 
 
 load_ai_config()

--- a/app/routes.py
+++ b/app/routes.py
@@ -784,6 +784,8 @@ def ai_config():
             base_url = 'https://api.openai.com/v1'
         if not api_key:
             api_key = load_ai_config().get('api_key', '')
+    elif provider == 'openai-oauth':
+        pass
     else:
         return jsonify({'error': 'Unknown provider'}), 400
     save_ai_config(provider, base_url, model, api_key, embedding_model)
@@ -837,6 +839,39 @@ def api_ai_check_models():
         supported = check_tool_support(model, base_url)
         results.append({'model': model, 'tool_support': supported})
     return jsonify({'base_url': base_url, 'results': results})
+
+# ── /api/ai/oauth/* ────────────────────────────────────────
+@app.route('/api/ai/oauth/status', methods=['GET'])
+def api_oauth_status():
+    from ollama_client import check_oauth_proxy, check_oauth_auth
+    return jsonify({
+        'signed_in': check_oauth_auth(),
+        'proxy_running': check_oauth_proxy(),
+    })
+
+@app.route('/api/ai/oauth/models', methods=['GET'])
+def api_oauth_models():
+    from ollama_client import fetch_oauth_models, check_oauth_proxy
+    if not check_oauth_proxy():
+        return jsonify({'error': 'Proxy nicht erreichbar'}), 502
+    models = fetch_oauth_models()
+    return jsonify({'models': models})
+
+@app.route('/api/ai/oauth/proxy/start', methods=['POST'])
+def api_oauth_proxy_start():
+    from ollama_client import start_oauth_proxy
+    result = start_oauth_proxy()
+    if result is True:
+        return jsonify({'status': 'started'})
+    return jsonify({'error': str(result)}), 500
+
+@app.route('/api/ai/oauth/proxy/stop', methods=['POST'])
+def api_oauth_proxy_stop():
+    from ollama_client import stop_oauth_proxy
+    result = stop_oauth_proxy()
+    if result is True:
+        return jsonify({'status': 'stopped'})
+    return jsonify({'error': str(result)}), 500
 
 # ── /api/vault/* ───────────────────────────────────────────
 @app.route('/api/vault/entries', methods=['GET'])

--- a/core/config.py
+++ b/core/config.py
@@ -41,6 +41,20 @@ def _openai_prefixes():
     raw = os.environ.get("OPENAI_MODEL_PREFIXES", "gpt-,o1-,o3-,claude-,gemini-,minimax-")
     return [p.strip() for p in raw.split(",") if p.strip()]
 
+def _is_chatgpt_oauth():
+    import json
+    from pathlib import Path
+    cfg_file = Path(__file__).parent.parent / 'data' / 'ai_config.json'
+    if cfg_file.exists():
+        try:
+            fc = json.loads(cfg_file.read_text())
+            return fc.get('provider') == 'openai-oauth'
+        except Exception:
+            pass
+    return False
+
 def _is_openai(model):
+    if _is_chatgpt_oauth():
+        return True
     ob, ok, oms = _openai_cfg()
     return ob and (model in oms or any(model.startswith(p) for p in _openai_prefixes()))

--- a/core/llm.py
+++ b/core/llm.py
@@ -26,6 +26,8 @@ def _load_openai_config():
                 base = str(fc.get('base_url', '')).rstrip('/')
                 key = str(fc.get('api_key', ''))
                 return base or 'https://api.openai.com/v1', key
+            if fc.get('provider') == 'openai-oauth':
+                return 'http://127.0.0.1:10531/v1', ''
         except (OSError, TypeError, ValueError, json.JSONDecodeError):
             pass
     return _openai_cfg()

--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -260,7 +260,7 @@ export default function HomePage() {
     text = text.trim();
     let targetChatId = options.chatId || activeChatId;
     const userMessageId = options.messageId || createMessageId();
-    if (!targetChatId) {
+    if (!targetChatId || (chats.length > 0 && !chats.some(c => c.id === targetChatId))) {
       const now = Date.now();
       const newChat = { id: createMessageId(), title: buildChatTitleFromText(text), messages: [{ role: 'user', content: text, id: userMessageId }], createdAt: now, updatedAt: now, project: null };
       setChats(prev => [newChat, ...prev]);
@@ -645,7 +645,7 @@ export default function HomePage() {
 
   useEffect(() => {
     if (chats.length === 0) { const initialChat = createEmptyChat(); setChats([initialChat]); setActiveChatId(initialChat.id); return; }
-    if (!activeChatId) { setActiveChatId(chats[0].id); return; }
+    if (!activeChatId || !chats.some(c => c.id === activeChatId)) { setActiveChatId(chats[0].id); return; }
     const urlChat = typeof window !== 'undefined' ? new URL(window.location.href).searchParams.get('chat') : null;
     if (urlChat && chats.some(c => c.id === urlChat) && urlChat !== activeChatId) setActiveChatId(urlChat);
   }, [chats.length, chats, activeChatId, setChats, setActiveChatId]);

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -56,6 +56,8 @@ body {
   --card-bg: var(--panel);
   --background: var(--input-bg);
   --bg: var(--bg-1);
+  --text: var(--ink);
+  --text-secondary: var(--muted);
 
   --radius-sm: 6px;
   --radius: 10px;

--- a/frontend/components/settings/ConfigTab.js
+++ b/frontend/components/settings/ConfigTab.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { SignInWithChatGPT } from '@openai-oauth/react';
 import { apiFetch } from '../../lib/api';
 import {
   getModelBaseName,
@@ -408,6 +409,7 @@ export default function ConfigTab({ tr, language }) {
           <select value={aiProvider} onChange={(e) => setAiProvider(e.target.value)}>
             <option value="ollama">Ollama (Lokal)</option>
             <option value="openai">OpenAI-kompatibel</option>
+            <option value="openai-oauth">ChatGPT (kostenlos)</option>
           </select>
         </div>
         {aiProvider === 'openai' ? (
@@ -423,6 +425,16 @@ export default function ConfigTab({ tr, language }) {
                 placeholder={openaiApiKeySet ? tr('API-Key ist gesetzt (neu eingeben zum Ändern)', 'API key is set (enter new to change)') : tr('API-Key eingeben', 'Enter API key')} />
             </div>
           </>
+        ) : aiProvider === 'openai-oauth' ? (
+          <div style={{marginTop: '0.5rem'}}>
+            <p style={{fontSize: '0.85rem', color: 'var(--muted)', marginBottom: '0.75rem', lineHeight: '1.5'}}>
+              {tr(
+                'Nutze deinen ChatGPT-Account kostenlos. Der openai-oauth-Proxy läuft lokal auf Port 10531.',
+                'Use your ChatGPT account for free. The openai-oauth proxy runs locally on port 10531.'
+              )}
+            </p>
+            <SignInWithChatGPT />
+          </div>
         ) : (
           <>
             <div className="input-group">

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,11 @@
       "name": "mynd-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^4.0.38",
         "@google/genai": "^1.48.0",
+        "@openai-oauth/ai-sdk": "^2.0.0",
+        "@openai-oauth/react": "^2.0.0",
+        "ai": "^6.0.234",
         "d3": "^7.8.5",
         "dompurify": "^3.4.12",
         "next": "^16.2.11",
@@ -28,6 +32,198 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "eslint": "^9.39.0",
         "eslint-config-next": "^16.2.10"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.156",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.156.tgz",
+      "integrity": "sha512-OeOfIlbp8DwlqBHDe3IbfAF6zRdKQg041UYaTz5gRFUwthZQXLCH5HK8JE0XCfhQFg92cGsQucOuXld+VFOhXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.40",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.16.tgz",
+      "integrity": "sha512-jC2r+StEuk8uIldfP4j8nBwOEBJ2TRwy/bz71SHMZ3NG6PSbvRPXGfyoHHR6JTm1O5GcIww0f6B8LznzkrseDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12",
+        "pkce-challenge": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.41.tgz",
+      "integrity": "sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.3.tgz",
+      "integrity": "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.12.tgz",
+      "integrity": "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@standard-schema/spec": "^1.1.0",
+        "@workflow/serde": "4.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "4.0.38",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.38.tgz",
+      "integrity": "sha512-i1lNjcEGaC5s6lKRuABuv90M75LgXdRBLpyhSElctd5p8av3+lQ/fkYl0E/lpscV/Qug3vaZlaoJw/nDG0fpvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/mcp": "2.0.16",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12",
+        "ai": "7.0.35",
+        "swr": "^2.4.1",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/@ai-sdk/gateway": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.27.tgz",
+      "integrity": "sha512-gqTMvV0N8/JirIZ3OzwjSZRYxzwZu/PeOFCKb8NB9fstWH39tI+L6CkeMNVou5/HCKEYAw6RCOHW59Vhquv8vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react/node_modules/ai": {
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-7.0.35.tgz",
+      "integrity": "sha512-en8xnTNoVJVWk/Y7TsXuTkc463ehuQUqrofjPs/TAd4O3h14QKmq4rWWG3/Eb05r3f2MvvxfCuXNnvhTdzyoTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "4.0.27",
+        "@ai-sdk/provider": "4.0.3",
+        "@ai-sdk/provider-utils": "5.0.12"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1338,6 +1534,99 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@openai-oauth/ai-sdk": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@openai-oauth/ai-sdk/-/ai-sdk-2.0.0.tgz",
+      "integrity": "sha512-hw7gm4e6pME+/wkPVvFVgRb7CijI7wXropPxbUoFn7dajjfmkTJ/hNobp/xP1Gx09ncF6BJ6N7rRRHvG1dJb/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/openai": "3.0.41",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@openai-oauth/core": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "ai": "^6.0.116"
+      }
+    },
+    "node_modules/@openai-oauth/ai-sdk/node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai-oauth/ai-sdk/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@openai-oauth/core": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@openai-oauth/core/-/core-2.0.0.tgz",
+      "integrity": "sha512-z9NYbfS8AQjriUnM8sPjGlpR//7oFwVxqYmabraXlwUokXfsUWk4V4O60jGWOJChUvE21B1A5G0CWDazM15+8g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@openai-oauth/react": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@openai-oauth/react/-/react-2.0.0.tgz",
+      "integrity": "sha512-3ex9yJjqmymyFboZQQe/Ab3WL9K2Cxz/ukXsO4iRC6yKZQxymrKbBNR5O8GZFkGIVy1O148V+sx0cN2cAwccgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai-oauth/core": "2.0.0",
+        "@openai-oauth/web": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0 || >=19.0.0"
+      }
+    },
+    "node_modules/@openai-oauth/web": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@openai-oauth/web/-/web-2.0.0.tgz",
+      "integrity": "sha512-+/RqOuXL6hqx2e7HL5YANtmZlkiq34G4a36JXNF1PY9oOEajF9VH+tLpHj3E96yxQWZfIz2jznueGI+L5YrGEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai-oauth/core": "2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1400,6 +1689,12 @@
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -2151,6 +2446,21 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@workflow/serde": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@workflow/serde/-/serde-4.1.0.tgz",
+      "integrity": "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/acorn": {
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
@@ -2181,6 +2491,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.234",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.234.tgz",
+      "integrity": "sha512-6/7Go3Z6j/rpMgTS8wWm38/pcDfvhSmQvNLvElwYezmjYKr5hNDMa4bGlnBtQcYNzbc1dLpWdbYNLJaas3AFPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.156",
+        "@ai-sdk/provider": "3.0.14",
+        "@ai-sdk/provider-utils": "4.0.40",
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.14.tgz",
+      "integrity": "sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ai/node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.40",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.40.tgz",
+      "integrity": "sha512-OL5IrpUm9Y8Dwy+w/vvFwPotS6m52O9W0op2oXgXdCROMJIBalBI0oro6OIBYkPxvm5Xg02GSkoQN25RlR0bnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.14",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -4138,6 +4495,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -5545,6 +5911,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -7170,6 +7542,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -8195,6 +8576,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.2.tgz",
+      "integrity": "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -8670,6 +9076,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vfile": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
@@ -8891,7 +9306,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint . --max-warnings=0"
   },
   "dependencies": {
+    "@ai-sdk/react": "^4.0.38",
     "@google/genai": "^1.48.0",
+    "@openai-oauth/ai-sdk": "^2.0.0",
+    "@openai-oauth/react": "^2.0.0",
+    "ai": "^6.0.234",
     "d3": "^7.8.5",
     "dompurify": "^3.4.12",
     "next": "^16.2.11",


### PR DESCRIPTION
### ChatGPT als nativen KI-Anbieter integriert

**Frontend:**
- `@openai-oauth/react` installiert mit `SignInWithChatGPT`-Button
- Neuer Provider `ChatGPT (kostenlos)` in den KI-Einstellungen
- Ein-Klick-Anmeldung mit ChatGPT-Account

**Backend:**
- Neuer Provider `openai-oauth` in `ai_config.json`
- Proxy-Management-Endpoints: `/api/ai/oauth/status`, `/api/ai/oauth/models`, `/api/ai/oauth/proxy/start`, `/api/ai/oauth/proxy/stop`
- `core/llm.py` + `core/config.py`: ChatGPT-Modelle werden automatisch an den lokalen Proxy (`http://127.0.0.1:10531/v1\') weitergeleitet