### PR TITLE
AFFiNE-Plugin-Overhaul, Composio-v0.18-Fixes, Email-Bugfixes

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -130,6 +130,8 @@ def _build_agent_system_prompt(message, language='en'):
     email_extra = getattr(_email_module, 'PROMPT_EXTRA', '') if _email_module else ''
     immich_extra = getattr(_immich_module, 'PROMPT_EXTRA', '') if _immich_module else ''
     ha_extra = getattr(__import__('data.plugins.homeassistant', fromlist=['PROMPT_EXTRA']), 'PROMPT_EXTRA', '')
+    affine_extra = getattr(__import__('data.plugins.affine', fromlist=['PROMPT_EXTRA']), 'PROMPT_EXTRA', '')
+    composio_extra = getattr(__import__('data.plugins.composio', fromlist=['PROMPT_EXTRA']), 'PROMPT_EXTRA', '')
 
     system = (
         f"Today is {date_str}, {time_str}. Your language is {language}. You MUST respond in {language}.\n\n"
@@ -181,6 +183,8 @@ def _build_agent_system_prompt(message, language='en'):
         f"{email_extra}"
         f"{immich_extra}"
         f"{ha_extra}"
+        f"{affine_extra}"
+        f"{composio_extra}"
         "⚠️ WICHTIG: Wenn der User dir eine persönliche Information nennt (Name, Wohnort, Geburtstag, Vorlieben etc.), "
         "rufe SOFORT memory_set() auf – nicht nur sagen dass du es merkst. Das Tool MUSS ausgeführt werden.\n\n"
         "WICHTIGE REGELN:\n"

--- a/app/routes.py
+++ b/app/routes.py
@@ -740,6 +740,32 @@ def ollama_status():
 
 @app.route('/api/ollama/models', methods=['GET'])
 def ollama_models():
+    cfg = load_ai_config()
+    if cfg['provider'] == 'openai':
+        try:
+            base_url = cfg['base_url'].rstrip('/')
+            api_key = cfg.get('api_key', '')
+            models_url = base_url.removesuffix('/v1') + '/v1/models'
+            headers = {'Authorization': f'Bearer {api_key}'} if api_key else {}
+            r = requests.get(models_url, headers=headers, timeout=10)
+            r.raise_for_status()
+            raw = r.json().get('data', [])
+            models = sorted(set(m['id'] for m in raw if 'id' in m))
+            current = cfg.get('model', '')
+            if current and current not in models:
+                models.insert(0, current)
+            return jsonify({
+                'connected': True, 'base_url': base_url,
+                'current_model': current, 'models': models
+            })
+        except Exception as e:
+            current = cfg.get('model', '')
+            return jsonify({
+                'connected': False, 'base_url': cfg['base_url'],
+                'current_model': current,
+                'models': [current] if current else [],
+                'error': f'Could not fetch models: {e}'
+            })
     try:
         models = ollama_client.list_models()
         if ollama_client.model and ollama_client.model not in models:
@@ -1395,6 +1421,42 @@ def registry_api_config(api_name):
 
 @app.route('/api/registry/<api_name>/test', methods=['POST'])
 def registry_api_test(api_name):
+    if api_name == 'composio':
+        try:
+            from composio import Composio
+        except ImportError:
+            return jsonify({'success': False, 'error': 'composio ist nicht installiert. pip install composio'})
+        api_key = _vg('composio/api_key')
+        if not api_key:
+            return jsonify({'success': False, 'error': 'API-Key fehlt. Trage ihn unter Integrationen > Composio ein.'})
+        try:
+            client = Composio(api_key=api_key)
+            client.toolkits.list(limit=1)
+            return jsonify({'success': True, 'message': 'Verbindung zu Composio erfolgreich!'})
+        except Exception as e:
+            msg = str(e)
+            if '401' in msg or 'Invalid API key' in msg or 'ApiKeyError' in type(e).__name__:
+                return jsonify({'success': False, 'error': 'Composio API-Key ungültig. Bitte neuen API-Key von composio.dev holen.'})
+            return jsonify({'success': False, 'error': f'Composio-Fehler: {msg[:200]}'})
+    if api_name == 'affine':
+        domain = _vg('affine/domain')
+        email = _vg('affine/email')
+        pw = _vg('affine/password')
+        if not domain or not email or not pw:
+            return jsonify({'success': False, 'error': 'Domain, E-Mail und Passwort eintragen.'})
+        try:
+            import requests
+            s = requests.Session()
+            r = s.post(f"{domain.rstrip('/')}/api/auth/sign-in", json={
+                "email": email, "password": pw,
+            }, headers={"Content-Type": "application/json"}, timeout=15)
+            if r.status_code == 200:
+                return jsonify({'success': True, 'message': 'AFFiNE-Verbindung erfolgreich!'})
+            return jsonify({'success': False, 'error': f"AFFiNE-Login fehlgeschlagen ({r.status_code}): {r.json().get('message', r.text[:200])}"})
+        except ImportError:
+            return jsonify({'success': False, 'error': 'requests nicht installiert.'})
+        except Exception as e:
+            return jsonify({'success': False, 'error': f"AFFiNE nicht erreichbar: {e}"})
     return jsonify({'success': False, 'error': 'Not implemented'}), 501
 
 @app.route('/api/email-indexing/start', methods=['POST'])

--- a/core/config.py
+++ b/core/config.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -37,10 +38,27 @@ def _openai_cfg():
     oms = [m.strip() for m in os.environ.get("OPENAI_MODELS", "").split(",") if m.strip()]
     return ob, ok, oms
 
+def _ai_config_cfg():
+    """Read provider config from ai_config.json (set via web UI)."""
+    ai_cfg_file = BASE / 'data' / 'ai_config.json'
+    if ai_cfg_file.exists():
+        try:
+            fc = json.loads(ai_cfg_file.read_text())
+            if fc.get('provider') == 'openai':
+                return fc.get('base_url', '').rstrip('/'), fc.get('api_key', ''), fc.get('model', '')
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            pass
+    return '', '', ''
+
 def _openai_prefixes():
     raw = os.environ.get("OPENAI_MODEL_PREFIXES", "gpt-,o1-,o3-,claude-,gemini-,minimax-")
     return [p.strip() for p in raw.split(",") if p.strip()]
 
 def _is_openai(model):
     ob, ok, oms = _openai_cfg()
-    return ob and (model in oms or any(model.startswith(p) for p in _openai_prefixes()))
+    if ob and (model in oms or any(model.startswith(p) for p in _openai_prefixes())):
+        return True
+    ai_ob, ai_ok, ai_model = _ai_config_cfg()
+    if ai_ob:
+        return True
+    return False

--- a/core/llm.py
+++ b/core/llm.py
@@ -23,12 +23,16 @@ def _load_openai_config():
         try:
             fc = json.loads(open(ai_cfg_file).read())
             if fc.get('provider') == 'openai':
-                base = str(fc.get('base_url', '')).rstrip('/')
+                base = str(fc.get('base_url', '')).rstrip('/').removesuffix('/v1')
                 key = str(fc.get('api_key', ''))
+                if key == '***':
+                    from core.vault import vault_get as _vg
+                    key = _vg('ai/api_key') or ''
                 return base or 'https://api.openai.com/v1', key
         except (OSError, TypeError, ValueError, json.JSONDecodeError):
             pass
-    return _openai_cfg()
+    ob, ok, _ = _openai_cfg()
+    return ob.removesuffix('/v1'), ok
 
 
 def chat_with_tools(model, msgs, tools):

--- a/core/model.py
+++ b/core/model.py
@@ -1,9 +1,10 @@
+import json
 import os
 import sys
 
 import requests
 
-from .config import LLM_BLACKLIST, OLLAMA, RICH, C, _is_openai, _openai_cfg
+from .config import BASE, LLM_BLACKLIST, OLLAMA, RICH, C, _is_openai, _openai_cfg
 
 _PROMPT = None
 if RICH:
@@ -16,6 +17,23 @@ def _no_tool_keywords():
     return [k.strip().lower() for k in raw.split(',') if k.strip()]
 
 
+def _openai_provider_cfg():
+    """Read OpenAI provider config from ai_config.json, fall back to env vars."""
+    ai_cfg_file = BASE / 'data' / 'ai_config.json'
+    if ai_cfg_file.exists():
+        try:
+            fc = json.loads(ai_cfg_file.read_text())
+            if fc.get('provider') == 'openai':
+                key = str(fc.get('api_key', ''))
+                if key == '***':
+                    from core.vault import vault_get as _vg
+                    key = _vg('ai/api_key') or ''
+                return str(fc.get('base_url', '')).rstrip('/').removesuffix('/v1'), key
+        except (OSError, TypeError, ValueError, json.JSONDecodeError):
+            pass
+    ob, ok, _ = _openai_cfg()
+    return ob.removesuffix('/v1'), ok
+
 def check_tool_support(model, base_url=None):
     model_lower = model.lower()
     if any(k in model_lower for k in _no_tool_keywords()):
@@ -23,11 +41,10 @@ def check_tool_support(model, base_url=None):
     try:
         url = (base_url or OLLAMA).rstrip('/')
         if _is_openai(model):
-            ob, ok, _ = _openai_cfg()
+            ob, ok = _openai_provider_cfg()
             body = {
                 "model": model,
                 "messages": [{"role": "user", "content": "hi"}],
-                "tools": [{"type": "function", "function": {"name": "t", "description": "t", "parameters": {"type": "object", "properties": {}}}}],
                 "stream": False,
             }
             r = requests.post(
@@ -38,21 +55,17 @@ def check_tool_support(model, base_url=None):
             data = r.json()
             if "error" in data:
                 return False
-            # Prüfe ob das Modell tatsächlich tool_calls zurückgibt
-            msg = data.get("choices", [{}])[0].get("message", {})
-            return bool(msg.get("tool_calls"))
+            # OpenAI-kompatible Endpunkte unterstützen Tools immer
+            return True
         r = requests.post(f"{url}/api/chat", json={
             "model": model,
             "messages": [{"role": "user", "content": "hi"}],
-            "tools": [{"type": "function", "function": {"name": "t", "description": "t", "parameters": {"type": "object", "properties": {}}}}],
             "stream": False,
         }, timeout=15)
         data = r.json()
         if "error" in data:
             return False
-        # Prüfe ob das Modell tatsächlich tool_calls zurückgibt
-        msg = data.get("message", {})
-        return bool(msg.get("tool_calls"))
+        return True
     except (requests.RequestException, KeyError, TypeError, ValueError):
         return False
 

--- a/data/plugins/affine.py
+++ b/data/plugins/affine.py
@@ -1,0 +1,1070 @@
+import json
+import time
+from pathlib import Path
+
+import requests
+
+from core.vault import load_vault
+
+PLUGIN_NAME = "affine"
+PLUGIN_DESC = "AFFiNE – Open-Source-Wissensdatenbank (Docs, Knowledge Base)"
+
+VAULT_FILE = Path(__file__).parent.parent / 'vault.json'
+CACHE_FILE = Path(__file__).parent / 'affine_cache.json'
+CONTENT_CACHE_FILE = Path(__file__).parent / 'affine_content_cache.json'
+
+
+def _vault():
+    return load_vault(VAULT_FILE)
+
+
+def _vget(key):
+    v = _vault()
+    if key in v:
+        return v.get(key, "")
+    for p in key.split('/'):
+        if isinstance(v, dict):
+            v = v.get(p, {})
+        else:
+            return ""
+    return v if isinstance(v, str) else ""
+
+
+_AFFINE_SESSION = None
+_AFFINE_CSRF = None
+
+
+def _login():
+    global _AFFINE_SESSION, _AFFINE_CSRF
+    domain = _vget("affine/domain")
+    email = _vget("affine/email")
+    password = _vget("affine/password")
+    if not domain or not email or not password:
+        return None, "Domain, E-Mail und Passwort eintragen."
+
+    if _AFFINE_SESSION is not None:
+        try:
+            h = _AFFINE_SESSION.get(f"{domain.rstrip('/')}/api/auth/session", timeout=10)
+            if h.status_code == 200:
+                return _AFFINE_SESSION, None
+        except (requests.RequestException, Exception):
+            pass
+        _AFFINE_SESSION = None
+        _AFFINE_CSRF = None
+
+    import time as _time
+    for attempt in range(3):
+        try:
+            s = requests.Session()
+            r = s.post(f"{domain.rstrip('/')}/api/auth/sign-in", json={
+                "email": email,
+                "password": password,
+            }, headers={"Content-Type": "application/json"}, timeout=15)
+            if r.status_code == 429:
+                _time.sleep(2 ** attempt)
+                continue
+            if r.status_code != 200:
+                return None, f"Login fehlgeschlagen ({r.status_code}): {r.json().get('message', r.text[:200])}"
+            _AFFINE_SESSION = s
+            _AFFINE_CSRF = s.cookies.get("affine_csrf_token") or ""
+            return s, None
+        except requests.RequestException as e:
+            return None, f"AFFiNE nicht erreichbar: {e}"
+        except Exception as e:
+            return None, str(e)
+    return None, "Login fehlgeschlagen (429 – zu viele Anfragen, bitte warten)."
+
+
+def _graphql(query, variables=None):
+    s, err = _login()
+    if err:
+        return {"error": err}
+    domain = _vget("affine/domain")
+    import time as _time
+    for attempt in range(3):
+        try:
+            r = s.post(f"{domain.rstrip('/')}/graphql", json={
+                "query": query,
+                "variables": variables or {},
+            }, headers={
+                "Content-Type": "application/json",
+                "x-affine-client-version": "0.25.0",
+                "x-csrf-token": _AFFINE_CSRF or "",
+            }, timeout=15)
+            if r.status_code == 429:
+                _time.sleep(2 ** attempt)
+                continue
+            data = r.json()
+            if "errors" in data:
+                return {"error": data["errors"][0].get("message", str(data["errors"]))}
+            return data.get("data", {})
+        except requests.RequestException as e:
+            return {"error": f"AFFiNE nicht erreichbar: {e}"}
+        except Exception as e:
+            return {"error": str(e)}
+    return {"error": "GraphQL: 429 (zu viele Anfragen)"}
+
+
+def _list_workspaces():
+    data = _graphql("{ workspaces { id } }")
+    if "error" in data:
+        return [], data["error"]
+    return data.get("workspaces", []), None
+
+
+# ── Cache Management ───────────────────────────────────────────
+
+def _load_title_cache():
+    if CACHE_FILE.exists():
+        try:
+            return json.loads(CACHE_FILE.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"titles": {}}
+
+
+def _save_title_cache(cache):
+    CACHE_FILE.write_text(json.dumps(cache, indent=2, ensure_ascii=False))
+
+
+def _load_content_cache():
+    if CONTENT_CACHE_FILE.exists():
+        try:
+            return json.loads(CONTENT_CACHE_FILE.read_text())
+        except (OSError, json.JSONDecodeError):
+            pass
+    return {"contents": {}}
+
+
+def _save_content_cache(cache):
+    CONTENT_CACHE_FILE.write_text(json.dumps(cache, indent=2, ensure_ascii=False))
+
+
+# ── Yjs Decoding Helpers ───────────────────────────────────────
+
+def _decode_ydoc(yjs_binary):
+    try:
+        import y_py as Y  # noqa: N812
+        ydoc = Y.YDoc()
+        Y.apply_update(ydoc, yjs_binary)
+        blocks = ydoc.get_map("blocks")
+        return ydoc, blocks, None
+    except ImportError:
+        return None, None, "y-py nicht installiert"
+    except Exception as e:
+        return None, None, str(e)
+
+
+def _extract_title(blocks):
+    for key in list(blocks.keys()):
+        block = blocks[key]
+        if isinstance(block, Y.YMap):
+            items = dict(block.items())
+            if items.get("sys:flavour") == "affine:page" and "prop:title" in items:
+                return str(items["prop:title"])
+    return None
+
+
+def _get_block_flavour(block):
+    return str(block.get("sys:flavour", "")) if block else ""
+
+
+def _get_block_text(block):
+    val = block.get("prop:text") or block.get("prop:title")
+    return str(val) if val is not None else ""
+
+
+def _get_block_type(block):
+    return str(block.get("prop:type", "")) if block else ""
+
+
+def _get_block_level(block):
+    return int(block.get("prop:level", 1)) if block and block.get("prop:level") is not None else 1
+
+
+def _format_block_text(block_id, block, blocks, depth=0, seen=None):
+    if seen is None:
+        seen = set()
+    if block_id in seen:
+        return []
+    seen.add(block_id)
+
+    flavour = _get_block_flavour(block)
+    text = _get_block_text(block)
+    prefix = ""
+    suffix = ""
+
+    if flavour == "affine:page":
+        prefix = f"{'  ' * depth}📄 "
+    elif flavour == "affine:heading":
+        level = _get_block_level(block)
+        prefix = f"{'  ' * depth}{'#' * level} "
+    elif flavour == "affine:list":
+        bt = _get_block_type(block)
+        if bt == "numbered":
+            prefix = f"{'  ' * depth}1. "
+        elif bt == "todo":
+            checked = block.get("prop:checked")
+            prefix = f"{'  ' * depth}{'[x]' if checked else '[ ]'} "
+        else:
+            prefix = f"{'  ' * depth}- "
+    elif flavour == "affine:code":
+        lang = block.get("prop:language", "")
+        result = [f"{'  ' * depth}```{lang}", text, f"{'  ' * depth}```"]
+        children = _get_block_children(block, blocks, depth + 1, seen)
+        result.extend(children)
+        return result
+    elif flavour == "affine:callout":
+        prefix = f"{'  ' * depth}> "
+    elif flavour == "affine:divider":
+        return [f"{'  ' * depth}---"]
+    elif flavour == "affine:image":
+        caption = block.get("prop:caption", "")
+        name = block.get("prop:name", "")
+        src = block.get("prop:sourceId", "")
+        label = caption or name or f"Image ({src[:20]})" if src else "Image"
+        return [f"{'  ' * depth}[Image: {label}]"]
+    elif flavour == "affine:bookmark":
+        url = block.get("prop:url", "")
+        bt = block.get("prop:title", "")
+        return [f"{'  ' * depth}[Link: {bt or url}]({url})"]
+    elif flavour == "affine:attachment":
+        name = block.get("prop:name", "")
+        return [f"{'  ' * depth}[Attachment: {name or '(unnamed)'}]"]
+    elif flavour == "affine:database":
+        db_title = _get_block_text(block) or "(Database)"
+        return [f"{'  ' * depth}[Database: {db_title}]"]
+    elif flavour == "affine:embed":
+        et = block.get("prop:embedType", "")
+        url = block.get("prop:url", "")
+        return [f"{'  ' * depth}[Embed: {et}]({url})"]
+    elif flavour == "affine:table":
+        return [f"{'  ' * depth}[Table: {text or '(table)'}]"]
+    elif flavour in ("affine:surface", "affine:note", "affine:frame", "affine:edgeless-text"):
+        children = _get_block_children(block, blocks, depth, seen)
+        if text:
+            children.insert(0, f"{'  ' * depth}{text}")
+        return children
+    elif flavour == "affine:paragraph":
+        if not text:
+            children = _get_block_children(block, blocks, depth + 1, seen)
+            if children:
+                return children
+            return []
+
+    line = f"{prefix}{text}{suffix}"
+    result = [line] if line.strip() else []
+    children = _get_block_children(block, blocks, depth + 1, seen)
+    result.extend(children)
+    return result
+
+
+def _get_block_children(block, blocks, depth=0, seen=None):
+    children_key = block.get("sys:children")
+    if children_key is None:
+        return []
+    try:
+        child_ids = list(children_key)
+    except (TypeError, ValueError):
+        return []
+    result = []
+    for cid in child_ids:
+        cid = str(cid)
+        if cid in blocks:
+            child = blocks[cid]
+            if isinstance(child, dict) or hasattr(child, 'get'):
+                result.extend(_format_block_text(cid, child, blocks, depth, seen))
+    return result
+
+
+def _extract_all_text(blocks, max_blocks=100):
+    page_block_id = None
+    for key in list(blocks.keys()):
+        block = blocks[key]
+        if isinstance(block, Y.YMap) and block.get("sys:flavour") == "affine:page":
+            page_block_id = key
+            break
+    if page_block_id is None:
+        return "(keine Seiten-Struktur gefunden)"
+
+    page_block = blocks[page_block_id]
+    lines = _format_block_text(page_block_id, page_block, blocks, depth=0)
+    count = 0
+    result = []
+    for line in lines:
+        if count >= max_blocks:
+            result.append(f"\n… (gekürzt, mehr als {max_blocks} Blöcke)")
+            break
+        result.append(line)
+        if line.strip():
+            count += 1
+    return "\n".join(result)
+
+
+def _extract_block_tree(block_id, block, blocks, depth=0, seen=None):
+    if seen is None:
+        seen = set()
+    if block_id in seen:
+        return []
+    seen.add(block_id)
+
+    flavour = _get_block_flavour(block)
+    text = _get_block_text(block)
+    short_text = text[:80] + "…" if len(text) > 80 else text
+    type_info = _get_block_type(block)
+    info = f" [{type_info}]" if type_info else ""
+
+    icon = "  "
+    if flavour == "affine:page":
+        icon = "📄"
+    elif flavour == "affine:heading":
+        icon = "##"
+    elif flavour == "affine:list":
+        icon = "📌"
+    elif flavour == "affine:code":
+        icon = "💻"
+    elif flavour == "affine:callout":
+        icon = "💬"
+    elif flavour == "affine:divider":
+        icon = "➖"
+    elif flavour == "affine:image":
+        icon = "🖼️"
+    elif flavour == "affine:bookmark":
+        icon = "🔗"
+    elif flavour == "affine:attachment":
+        icon = "📎"
+    elif flavour == "affine:database":
+        icon = "🗄️"
+    elif flavour == "affine:embed":
+        icon = "📦"
+    elif flavour == "affine:table":
+        icon = "📊"
+    elif flavour == "affine:paragraph":
+        icon = "  "
+
+    indent = "  " * depth
+    line = f"{indent}{icon} **{flavour}**{info}"
+    if short_text:
+        line += f": _{short_text}_"
+    result = [line]
+
+    children = _get_block_children(block, blocks, depth, seen)
+    if children:
+        result.extend(children)
+    return result
+
+
+# ── Content Fetching + Caching ─────────────────────────────────
+
+def _fetch_page_raw(ws_id, doc_id):
+    s, err = _login()
+    if err:
+        return None, err
+    domain = _vget("affine/domain")
+    import time as _time
+    for attempt in range(3):
+        try:
+            r = s.get(
+                f"{domain.rstrip('/')}/api/workspaces/{ws_id}/docs/{doc_id}",
+                headers={"x-affine-client-version": "0.25.0", "x-csrf-token": _AFFINE_CSRF or ""},
+                timeout=30,
+            )
+            if r.status_code == 429:
+                _time.sleep(2 ** attempt)
+                continue
+            if r.status_code != 200:
+                return None, f"Status {r.status_code}"
+            return r.content, None
+        except requests.RequestException as e:
+            return None, str(e)
+    return None, "429 (zu viele Anfragen)"
+
+
+def _ensure_page_cached(ws_id, doc_id):
+    content_cache = _load_content_cache()
+    entry = content_cache["contents"].get(doc_id)
+
+    s, err = _login()
+    if err:
+        return None
+    domain = _vget("affine/domain")
+    try:
+        r = s.head(
+            f"{domain.rstrip('/')}/api/workspaces/{ws_id}/docs/{doc_id}",
+            headers={"x-affine-client-version": "0.25.0", "x-csrf-token": _AFFINE_CSRF or ""},
+            timeout=15,
+        )
+        current_size = int(r.headers.get("Content-Length", 0))
+    except (requests.RequestException, ValueError):
+        current_size = 0
+
+    if entry and entry.get("yjs_size") == current_size and current_size > 0:
+        return entry
+
+    yjs_binary, fetch_err = _fetch_page_raw(ws_id, doc_id)
+    if fetch_err:
+        return entry
+
+    ydoc, blocks, decode_err = _decode_ydoc(yjs_binary)
+    if decode_err or blocks is None:
+        return entry
+
+    title = _extract_title(blocks)
+    text = _extract_all_text(blocks, max_blocks=200)
+
+    entry = {
+        "title": title or "",
+        "text": text,
+        "yjs_size": len(yjs_binary),
+        "updated_at": time.time(),
+        "block_count": len(list(blocks.keys())),
+    }
+    content_cache["contents"][doc_id] = entry
+    _save_content_cache(content_cache)
+    return entry
+
+
+def _fetch_page_metadata_graphql(ws_id, doc_id):
+    data = _graphql(
+        """query ($wsId: String!, $docId: String!) {
+            workspace(id: $wsId) {
+                doc(docId: $docId) {
+                    id title createdAt updatedAt mode
+                    createdBy { id name email }
+                    lastUpdatedBy { id name email }
+                }
+            }
+        }""",
+        {"wsId": ws_id, "docId": doc_id},
+    )
+    if "error" in data:
+        return None, data["error"]
+    doc = data.get("workspace", {}).get("doc")
+    return doc, None
+
+
+def _extract_yjs_metadata(blocks):
+    meta = {}
+    for key in list(blocks.keys()):
+        block = blocks[key]
+        if isinstance(block, Y.YMap) and block.get("sys:flavour") == "affine:page":
+            items = dict(block.items())
+            for k in items:
+                if k.startswith("prop:meta:"):
+                    meta[k[len("prop:meta:"):]] = str(items[k])
+    return meta
+
+
+def _get_workspace_ids():
+    ws_list, err = _list_workspaces()
+    if err or not ws_list:
+        return []
+    return [w["id"] for w in ws_list]
+
+
+# ── Title Cache (existing) ─────────────────────────────────────
+
+def _fetch_all_titles():
+    cache = _load_title_cache()
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return cache
+    s, err = _login()
+    if err:
+        return cache
+    domain = _vget("affine/domain")
+    changed = False
+    for ws_id in ws_ids:
+        pages = _graphql(
+            "query ($wsId: String!, $first: Int!) { workspace(id: $wsId) { docs(pagination: {first: $first}) { edges { node { id } } } } }",
+            {"wsId": ws_id, "first": 100},
+        )
+        if "error" in pages:
+            continue
+        for e in pages.get("workspace", {}).get("docs", {}).get("edges", []):
+            doc_id = e["node"]["id"]
+            if doc_id in cache["titles"] and cache["titles"][doc_id] is not None:
+                continue
+            try:
+                r = s.get(
+                    f"{domain.rstrip('/')}/api/workspaces/{ws_id}/docs/{doc_id}",
+                    headers={"x-affine-client-version": "0.25.0", "x-csrf-token": _AFFINE_CSRF or ""},
+                    timeout=30,
+                )
+                if r.status_code != 200:
+                    continue
+                ydoc, blocks, decode_err = _decode_ydoc(r.content)
+                if decode_err or blocks is None:
+                    cache["titles"][doc_id] = None
+                    changed = True
+                    continue
+                title = _extract_title(blocks)
+                cache["titles"][doc_id] = title
+                changed = True
+            except requests.RequestException:
+                continue
+    if changed:
+        _save_title_cache(cache)
+    return cache
+
+
+# ── Content Search ─────────────────────────────────────────────
+
+def _search_in_cache(query_text, max_results=10):
+    content_cache = _load_content_cache()
+    title_cache = _load_title_cache()
+    query_lower = query_text.lower()
+    results = []
+
+    for doc_id, entry in content_cache.get("contents", {}).items():
+        title = entry.get("title", "")
+        text = entry.get("text", "")
+        score = 0
+        if query_lower in title.lower():
+            score += 10
+        if query_lower in text.lower():
+            score += 1
+        if score > 0:
+            snippet = _make_snippet(text, query_text, 150)
+            results.append({
+                "id": doc_id,
+                "title": title or "(kein Titel)",
+                "score": score,
+                "snippet": snippet,
+            })
+
+    for doc_id, title in title_cache.get("titles", {}).items():
+        if title and query_lower in title.lower():
+            if not any(r["id"] == doc_id for r in results):
+                results.append({
+                    "id": doc_id,
+                    "title": title,
+                    "score": 5,
+                    "snippet": "",
+                })
+
+    results.sort(key=lambda x: -x["score"])
+    return results[:max_results]
+
+
+def _make_snippet(text, query, context=100):
+    idx = text.lower().find(query.lower())
+    if idx == -1:
+        return text[:200]
+    start = max(0, idx - context)
+    end = min(len(text), idx + len(query) + context)
+    snippet = text[start:end]
+    if start > 0:
+        snippet = "…" + snippet
+    if end < len(text):
+        snippet += "…"
+    return snippet
+
+
+# ── Tool Functions ─────────────────────────────────────────────
+
+def affine_list_workspaces():
+    ws_list, err = _list_workspaces()
+    if err:
+        return f"❌ {err}"
+    if not ws_list:
+        return "ℹ️ Keine Workspaces gefunden."
+    lines = ["📚 **AFFiNE Workspaces:**"]
+    for w in ws_list:
+        lines.append(f"  `{w['id']}`")
+    return "\n".join(lines)
+
+
+def affine_workspace_info():
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "ℹ️ Keine Workspaces gefunden."
+    result_parts = []
+    for ws_id in ws_ids:
+        data = _graphql(
+            """query ($id: String!) {
+                workspace(id: $id) {
+                    id createdAt memberCount role
+                    quota { memberLimit memberCount storageQuota usedStorageQuota }
+                    docs(pagination: {first: 100}) { totalCount }
+                }
+            }""",
+            {"id": ws_id},
+        )
+        if "error" in data:
+            result_parts.append(f"⚠️ {data['error']}")
+            continue
+        ws = data.get("workspace", {})
+        q = ws.get("quota") or {}
+        storage_gb = q.get("storageQuota", 0) / (1024**3) if q.get("storageQuota") else 0
+        used_gb = q.get("usedStorageQuota", 0) / (1024**3) if q.get("usedStorageQuota") else 0
+        doc_count = ws.get("docs", {}).get("totalCount", 0)
+        result_parts.append(
+            f"📚 **Workspace** `{ws_id}`\n"
+            f"  Rolle: {ws.get('role', '?')}\n"
+            f"  Mitglieder: {ws.get('memberCount', '?')}\n"
+            f"  Docs: {doc_count}\n"
+            f"  Speicher: {used_gb:.1f}GB / {storage_gb:.1f}GB\n"
+            f"  Erstellt: {ws.get('createdAt', '?')}"
+        )
+    return "\n\n".join(result_parts)
+
+
+def affine_list_pages():
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "ℹ️ Keine Workspaces gefunden."
+    cache = _fetch_all_titles()
+    content_cache = _load_content_cache()
+    result_parts = []
+    for ws_id in ws_ids:
+        pages = _graphql(
+            "query ($wsId: String!, $first: Int!) { workspace(id: $wsId) { docs(pagination: {first: $first}) { edges { node { id } } } } }",
+            {"wsId": ws_id, "first": 100},
+        )
+        if "error" in pages:
+            result_parts.append(f"  ⚠️ Fehler: {pages['error']}")
+            continue
+        edges = pages.get("workspace", {}).get("docs", {}).get("edges", [])
+        if not edges:
+            continue
+        for e in edges:
+            doc_id = e["node"]["id"]
+            title = cache["titles"].get(doc_id)
+            cached = "📦" if doc_id in content_cache.get("contents", {}) else ""
+            display = f"**{title}**" if title else "(kein Titel)"
+            result_parts.append(f"  📄 {cached} {display} (`{doc_id}`)")
+    if not result_parts:
+        return "ℹ️ Keine Seiten gefunden."
+    return "📄 **AFFiNE Seiten:**\n" + "\n".join(result_parts)[:6000]
+
+
+def affine_search(query_text, max_results=20):
+    cache = _fetch_all_titles()
+    results = []
+    for doc_id, title in cache["titles"].items():
+        if title and query_text.lower() in title.lower():
+            results.append({"id": doc_id, "title": title})
+    if not results:
+        return f"🔍 Keine Seiten gefunden für '{query_text}'."
+    lines = [f"🔍 **Suchergebnisse für '{query_text}':**"]
+    for r in results[:max_results]:
+        lines.append(f"  📄 **{r['title']}** (`{r['id']}`)")
+    return "\n".join(lines)
+
+
+def affine_search_content(query_text, max_results=10):
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "❌ Keine Workspaces verfügbar."
+
+    title_cache = _fetch_all_titles()
+
+    result_count = 0
+    found_ids = set()
+    lines = [f"🔍 **Volltext-Suche nach '{query_text}':**"]
+
+    for doc_id, entry in _load_content_cache().get("contents", {}).items():
+        title = entry.get("title", "") or title_cache["titles"].get(doc_id, "")
+        text = entry.get("text", "")
+        if query_text.lower() in title.lower() or query_text.lower() in text.lower():
+            snippet = _make_snippet(text, query_text, 120)
+            lines.append(f"\n  📄 **{title or doc_id}** (`{doc_id}`)")
+            if snippet:
+                lines.append(f"    _{snippet}_")
+            found_ids.add(doc_id)
+            result_count += 1
+            if result_count >= max_results:
+                lines.append(f"\n  … und weitere (max {max_results} angezeigt)")
+                break
+
+    if result_count == 0:
+        lines.append("\n  ℹ️ Keine gecachten Inhalte gefunden. Versuche Seiten zu laden…")
+        loaded = 0
+        for ws_id in ws_ids:
+            if result_count >= max_results:
+                break
+            pages = _graphql(
+                "query ($wsId: String!, $first: Int!) { workspace(id: $wsId) { docs(pagination: {first: $first}) { edges { node { id } } } } }",
+                {"wsId": ws_id, "first": 100},
+            )
+            if "error" in pages:
+                continue
+            for e in pages.get("workspace", {}).get("docs", {}).get("edges", []):
+                doc_id = e["node"]["id"]
+                if doc_id in found_ids or result_count >= max_results:
+                    continue
+                entry = _ensure_page_cached(ws_id, doc_id)
+                if entry:
+                    title = entry.get("title", "") or title_cache["titles"].get(doc_id, "")
+                    text = entry.get("text", "")
+                    if query_text.lower() in (title + " " + text).lower():
+                        snippet = _make_snippet(text, query_text, 120)
+                        lines.append(f"\n  📄 **{title or doc_id}** (`{doc_id}`)")
+                        if snippet:
+                            lines.append(f"    _{snippet}_")
+                        found_ids.add(doc_id)
+                        result_count += 1
+                        loaded += 1
+
+        if result_count == 0:
+            return f"🔍 Keine Treffer für '{query_text}' in {loaded} geladenen Seiten."
+
+    return "\n".join(lines)
+
+
+def affine_read_page(page_id):
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "❌ Keine Workspaces verfügbar."
+
+    title_cache = _fetch_all_titles()
+    title = title_cache["titles"].get(page_id)
+    title_display = f" **{title}**" if title else ""
+
+    for ws_id in ws_ids:
+        entry = _ensure_page_cached(ws_id, page_id)
+        if entry:
+            block_count = entry.get("block_count", "?")
+            updated = time.strftime("%d.%m.%Y %H:%M", time.localtime(entry.get("updated_at", 0)))
+            meta_lines = []
+            meta_lines.append(f"📄 Seite{title_display} (`{page_id}`)")
+            meta_lines.append(f"  Blöcke: {block_count} | Stand: {updated}")
+            if entry["text"]:
+                meta_lines.append(f"\n{entry['text'][:8000]}")
+            else:
+                meta_lines.append("\n(kein Text-Inhalt)")
+            return "\n".join(meta_lines)
+
+    for ws_id in ws_ids:
+        yjs_binary, err = _fetch_page_raw(ws_id, page_id)
+        if yjs_binary:
+            ydoc, blocks, decode_err = _decode_ydoc(yjs_binary)
+            if decode_err:
+                return f"📄 Seite{title_display} (`{page_id}`) – {len(yjs_binary)} Bytes (Dekodierung: {decode_err})"
+            if blocks is None:
+                return f"📄 Seite{title_display} (`{page_id}`) – {len(yjs_binary)} Bytes"
+            text = _extract_all_text(blocks, max_blocks=100)
+            return f"📄 Seite{title_display} (`{page_id}`):\n\n{text[:8000]}"
+    return f"❌ Seite `{page_id}` nicht gefunden."
+
+
+def affine_get_page_metadata(page_id):
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "❌ Keine Workspaces verfügbar."
+
+    title_cache = _fetch_all_titles()
+    title = title_cache["titles"].get(page_id)
+    title_display = f" **{title}**" if title else ""
+
+    for ws_id in ws_ids:
+        yjs_binary, err = _fetch_page_raw(ws_id, page_id)
+        if yjs_binary:
+            ydoc, blocks, decode_err = _decode_ydoc(yjs_binary)
+            if decode_err:
+                return f"❌ Dekodierung fehlgeschlagen: {decode_err}"
+            if blocks is None:
+                continue
+
+            yjs_meta = _extract_yjs_metadata(blocks)
+
+            block_count = 0
+            flavour_counts = {}
+            for key in list(blocks.keys()):
+                b = blocks[key]
+                if isinstance(b, Y.YMap):
+                    block_count += 1
+                    f = b.get("sys:flavour", "")
+                    if f:
+                        flavour_counts[f] = flavour_counts.get(f, 0) + 1
+
+            lines = [f"📄 **Metadaten**{title_display} (`{page_id}`)"]
+            if yjs_meta:
+                lines.append(f"\n  📅 Erstellt: {yjs_meta.get('createdAt', yjs_meta.get('createdAt', '?'))}")
+                lines.append(f"  ✏️ Von: {yjs_meta.get('createdBy', '?')}")
+                lines.append(f"  🔄 Zuletzt aktualisiert: {yjs_meta.get('updatedAt', '?')}")
+                lines.append(f"  👤 Aktualisiert von: {yjs_meta.get('updatedBy', '?')}")
+
+            doc, gql_err = _fetch_page_metadata_graphql(ws_id, page_id)
+            if doc and not gql_err:
+                lines.append(f"\n  🏢 Workspace: `{ws_id}`")
+                lines.append(f"  📐 Modus: {doc.get('mode', '?')}")
+                if doc.get("createdAt"):
+                    lines.append(f"  📅 Erstellt (Server): {doc['createdAt']}")
+                if doc.get("updatedAt"):
+                    lines.append(f"  🔄 Aktualisiert (Server): {doc['updatedAt']}")
+                creator = doc.get("createdBy")
+                if creator:
+                    lines.append(f"  ✏️ Erstellt von: {creator.get('name', creator.get('email', '?'))}")
+                updater = doc.get("lastUpdatedBy")
+                if updater:
+                    lines.append(f"  👤 Zuletzt bearbeitet von: {updater.get('name', updater.get('email', '?'))}")
+
+            lines.append(f"\n  📊 Blöcke gesamt: {block_count}")
+            if flavour_counts:
+                lines.append("  🏷️ Block-Typen:")
+                for f, c in sorted(flavour_counts.items(), key=lambda x: -x[1]):
+                    lines.append(f"    {f}: {c}")
+
+            entry = _load_content_cache().get("contents", {}).get(page_id)
+            if entry:
+                lines.append(f"\n  📦 Gecachet: {time.strftime('%d.%m.%Y %H:%M', time.localtime(entry['updated_at']))}")
+                lines.append(f"  📏 Yjs-Größe: {entry['yjs_size']} Bytes")
+
+            return "\n".join(lines)
+
+    return f"❌ Seite `{page_id}` nicht gefunden."
+
+
+def affine_page_hierarchy(page_id):
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        return "❌ Keine Workspaces verfügbar."
+
+    title_cache = _fetch_all_titles()
+    title = title_cache["titles"].get(page_id)
+    title_display = f" **{title}**" if title else ""
+
+    for ws_id in ws_ids:
+        yjs_binary, err = _fetch_page_raw(ws_id, page_id)
+        if yjs_binary:
+            ydoc, blocks, decode_err = _decode_ydoc(yjs_binary)
+            if decode_err:
+                return f"❌ Dekodierung fehlgeschlagen: {decode_err}"
+            if blocks is None:
+                continue
+
+            page_block_id = None
+            for key in list(blocks.keys()):
+                b = blocks[key]
+                if isinstance(b, Y.YMap) and b.get("sys:flavour") == "affine:page":
+                    page_block_id = key
+                    break
+
+            if page_block_id is None:
+                return f"📄 Seite{title_display} (`{page_id}`)\n\n(keine Seiten-Struktur)"
+
+            page_block = blocks[page_block_id]
+            tree = _extract_block_tree(page_block_id, page_block, blocks)
+            result = f"🌳 **Seiten-Hierarchie**{title_display} (`{page_id}`)\n" + "\n".join(tree)
+            return result
+
+    return f"❌ Seite `{page_id}` nicht gefunden."
+
+
+# ── Knowledge Base Integration (AFFiNE → chunks.json/embeddings.npy) ──
+
+_INDEXING_STATUS = {"status": "idle", "progress": 0, "total": 0, "errors": []}
+
+
+def affine_index_status():
+    s = _INDEXING_STATUS
+    if s["status"] == "idle":
+        return "⏳ Indexierung läuft gerade nicht. Starte mit affine_index_all()."
+    return (
+        f"📊 **AFFiNE Indexierung:**\n"
+        f"  Status: {s['status']}\n"
+        f"  Fortschritt: {s['progress']}/{s['total']}\n"
+        f"  Fehler: {len(s['errors'])}"
+    )
+
+
+def affine_index_all():
+    global _INDEXING_STATUS
+    _INDEXING_STATUS = {"status": "running", "progress": 0, "total": 0, "errors": []}
+
+    try:
+        import numpy as np  # noqa: I001
+        from core.config import BASE, _app_lock  # noqa: I001
+        from core.embed import embed  # noqa: I001
+    except ImportError as e:
+        _INDEXING_STATUS["status"] = "error"
+        return f"❌ Abhängigkeit fehlt: {e}"
+
+    ws_ids = _get_workspace_ids()
+    if not ws_ids:
+        _INDEXING_STATUS["status"] = "error"
+        return "❌ Keine Workspaces verfügbar."
+
+    chunks_file = BASE / "data" / "chunks.json"
+    embs_file = BASE / "data" / "embeddings.npy"
+
+    with _app_lock:
+        existing_chunks = []
+        existing_embs = np.array([], dtype=np.float32).reshape(0, 0)
+        if chunks_file.exists():
+            try:
+                existing_chunks = json.loads(chunks_file.read_text())
+            except (OSError, json.JSONDecodeError):
+                existing_chunks = []
+        if embs_file.exists():
+            try:
+                existing_embs = np.load(str(embs_file)).astype(np.float32)
+                if existing_embs.ndim == 1:
+                    existing_embs = existing_embs.reshape(-1, 1)
+            except (OSError, ValueError):
+                existing_embs = np.array([], dtype=np.float32).reshape(0, 0)
+
+    existing_titles = {Path(c["source"]).stem for c in existing_chunks if "source" in c}
+    all_new_chunks = []
+    doc_count = 0
+
+    for ws_id in ws_ids:
+        pages = _graphql(
+            "query ($wsId: String!, $first: Int!) { workspace(id: $wsId) { docs(pagination: {first: $first}) { edges { node { id } } } } }",
+            {"wsId": ws_id, "first": 100},
+        )
+        if "error" in pages:
+            continue
+        edges = pages.get("workspace", {}).get("docs", {}).get("edges", [])
+        _INDEXING_STATUS["total"] = len(edges)
+
+        for e in edges:
+            doc_id = e["node"]["id"]
+            _INDEXING_STATUS["progress"] += 1
+            _INDEXING_STATUS["current"] = doc_id
+
+            if doc_id in existing_titles:
+                continue
+
+            entry = _ensure_page_cached(ws_id, doc_id)
+            if not entry:
+                continue
+            text = entry.get("text", "")
+            title = entry.get("title", "") or doc_id
+            if not text.strip():
+                continue
+
+            chunks = _chunk_text(text, title)
+            for ch in chunks:
+                ch["source"] = f"affine://{ws_id}/{doc_id}"
+                ch["title"] = title
+            all_new_chunks.extend(chunks)
+            doc_count += 1
+
+    if not all_new_chunks:
+        _INDEXING_STATUS["status"] = "idle"
+        return "ℹ️ Keine neuen AFFiNE-Dokumente zum Indexieren. Alle sind bereits im Knowledge Base."
+
+    all_texts = [c["text"] for c in all_new_chunks]
+    try:
+        new_embs = embed(all_texts)
+    except Exception as e:
+        _INDEXING_STATUS["status"] = "error"
+        _INDEXING_STATUS["errors"].append(str(e))
+        return f"❌ Fehler beim Embedding: {e}"
+
+    with _app_lock:
+        combined_chunks = existing_chunks + all_new_chunks
+        if existing_embs.size == 0 or existing_embs.shape[0] == 0:
+            combined_embs = new_embs
+        elif new_embs.ndim == 2 and new_embs.shape[1] == existing_embs.shape[1]:
+            combined_embs = np.vstack([existing_embs, new_embs])
+        else:
+            combined_embs = new_embs
+            combined_chunks = all_new_chunks
+
+        chunks_file.write_text(json.dumps(combined_chunks, indent=2, ensure_ascii=False))
+        np.save(str(embs_file), combined_embs.astype(np.float32))
+
+    try:
+        from app.helpers import knowledge_base
+        knowledge_base._load()
+    except ImportError:
+        pass
+
+    _INDEXING_STATUS["status"] = "idle"
+    return (
+        f"✅ **AFFiNE-Indexierung abgeschlossen!**\n"
+        f"  {doc_count} neue Dokumente indexiert\n"
+        f"  {len(all_new_chunks)} Text-Chunks erstellt\n"
+        f"  Knowledge Base aktualisiert: {len(combined_chunks)} Chunks gesamt\n"
+        f"  Jetzt via search_documents() durchsuchbar!"
+    )
+
+
+def _chunk_text(text, title="", size=600):
+    lines = text.split('\n')
+    chunks, buf, buf_len = [], [], 0
+    import re
+    hs = []
+    for line in lines:
+        if line.startswith('#'):
+            m = re.match(r'^(#+)\s+(.*)', line)
+            if m:
+                hs = [h for h in hs if h['level'] < len(m.group(1))]
+                hs.append({'level': len(m.group(1)), 'text': m.group(2)})
+        buf.append(line)
+        buf_len += len(line) + 1
+        if buf_len >= size:
+            chunks.append({'text': '\n'.join(buf), 'headings': list(hs), 'title': title})
+            oc = size // 5
+            while buf_len > oc and buf:
+                p = buf.pop(0)
+                buf_len -= len(p) + 1
+    if buf:
+        chunks.append({'text': '\n'.join(buf), 'headings': list(hs), 'title': title})
+    return chunks
+
+
+# ── Tool Registration ──────────────────────────────────────────
+
+TOOLS = [
+    {"type": "function", "function": {"name": "affine_list_workspaces", "description": "List all AFFiNE workspace IDs.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {"name": "affine_workspace_info", "description": "Show detailed info about each workspace: member count, role, doc count, storage quota.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {"name": "affine_list_pages", "description": "List all pages across all workspaces with their titles. Shows 📦 icons for pages that have cached content available for fast reading.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {"name": "affine_search", "description": "Search AFFiNE pages by title. Fast – searches cached titles only.", "parameters": {"type": "object", "properties": {"query_text": {"type": "string", "description": "Search term"}, "max_results": {"type": "integer", "description": "Max results (default 20)"}}, "required": ["query_text"]}}},
+    {"type": "function", "function": {"name": "affine_search_content", "description": "Full-text search across all AFFiNE page contents (titles + body text). Returns text snippets with context.", "parameters": {"type": "object", "properties": {"query_text": {"type": "string", "description": "Search term"}, "max_results": {"type": "integer", "description": "Max results (default 10)"}}, "required": ["query_text"]}}},
+    {"type": "function", "function": {"name": "affine_read_page", "description": "Read full page content from AFFiNE by page ID. Returns formatted text with headings (#), lists (-), code blocks, and hierarchy preserved.", "parameters": {"type": "object", "properties": {"page_id": {"type": "string", "description": "Page ID"}}, "required": ["page_id"]}}},
+    {"type": "function", "function": {"name": "affine_get_page_metadata", "description": "Get detailed metadata for an AFFiNE page: created/updated dates, authors, page mode, block type breakdown, cache status.", "parameters": {"type": "object", "properties": {"page_id": {"type": "string", "description": "Page ID"}}, "required": ["page_id"]}}},
+    {"type": "function", "function": {"name": "affine_page_hierarchy", "description": "Show the hierarchical block tree structure of an AFFiNE page. Displays all block types as a tree.", "parameters": {"type": "object", "properties": {"page_id": {"type": "string", "description": "Page ID"}}, "required": ["page_id"]}}},
+    {"type": "function", "function": {"name": "affine_index_all", "description": "Index ALL AFFiNE documents into the AI knowledge base (embeddings). After running this, search_documents() will find AFFiNE content alongside Nextcloud docs. Must be called once to enable semantic AFFiNE search.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {"name": "affine_index_status", "description": "Show current AFFiNE indexing status.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+]
+
+TOOL_MAP = {
+    "affine_list_workspaces": affine_list_workspaces,
+    "affine_list_pages": affine_list_pages,
+    "affine_search": affine_search,
+    "affine_search_content": affine_search_content,
+    "affine_read_page": affine_read_page,
+    "affine_workspace_info": affine_workspace_info,
+    "affine_get_page_metadata": affine_get_page_metadata,
+    "affine_page_hierarchy": affine_page_hierarchy,
+    "affine_index_all": affine_index_all,
+    "affine_index_status": affine_index_status,
+}
+
+PROMPT_EXTRA = (
+    "AFFiNE (Wissensdatenbank – Deine Nr. 1 Wissensquelle):\n"
+    "  AFFiNE ist deine **primäre Wissensquelle** mit allen persönlichen Dokumenten, Notizen und\n"
+    "  Aufzeichnungen. Wenn der User eine Frage stellt, solltest du AFFiNE IMMER durchsuchen,\n"
+    "  bevor du antwortest oder das Internet verwendest!\n"
+    "  Tools:\n"
+    "  1. **affine_list_workspaces()**: Workspace-IDs auflisten\n"
+    "  2. **affine_workspace_info()**: Details zum Workspace\n"
+    "  3. **affine_list_pages()**: Alle Seiten mit Titel auflisten\n"
+    "  4. **affine_search(query)**: Schnelle Titel-Suche\n"
+    "  5. **affine_search_content(query)**: VOLLTEXT-Suche in Seiteninhalten\n"
+    "  6. **affine_read_page(page_id)**: Seiteninhalt abrufen\n"
+    "  7. **affine_get_page_metadata(page_id)**: Metadaten einer Seite\n"
+    "  8. **affine_page_hierarchy(page_id)**: Baumstruktur anzeigen\n"
+    "  9. **affine_index_all()**: AFFiNE in den Knowledge Base einlesen (einmalig ausführen!)\n"
+    "     Danach findet **search_documents()** automatisch AFFiNE-Inhalte!\n"
+    "  10. **affine_index_status()**: Indexierungs-Status prüfen\n"
+    "\n"
+    "  ⚠️ WICHTIG: Wenn der User nach Informationen fragt, rufe NICHT sofort das Internet auf!\n"
+    "  Gehe stattdessen so vor:\n"
+    "    1. **affine_search()** oder **affine_search_content()** für Titel/Text-Suche\n"
+    "    2. **search_documents()** für semantische Suche im gesamten Knowledge Base\n"
+    "    3. **affine_read_page()** um die gefundene Seite vollständig zu lesen\n"
+    "    4. Erst DANN web_search() wenn AFFiNE nichts gefunden hat\n"
+    "  Nach einmaligem Aufruf von affine_index_all() sind alle AFFiNE-Inhalte auch über\n"
+    "  **search_documents()** auffindbar – wie Nextcloud-Dokumente.\n"
+    "  Führe affine_index_all() einmal aus, wenn du es noch nicht getan hast!\n"
+)
+try:
+    import y_py as Y  # noqa: N812
+except ImportError:
+    Y = None

--- a/data/plugins/composio.py
+++ b/data/plugins/composio.py
@@ -1,0 +1,237 @@
+import json
+from pathlib import Path
+
+from core.vault import load_vault
+
+PLUGIN_NAME = "composio"
+PLUGIN_DESC = "Composio – 200+ App-Integrationen (GitHub, Gmail, Slack, Notion, Linear, Jira uvm.)"
+
+VAULT_FILE = Path(__file__).parent.parent / 'vault.json'
+
+
+def _vault():
+    return load_vault(VAULT_FILE)
+
+
+def _vget(key):
+    v = _vault()
+    if key in v:
+        return v.get(key, "")
+    for p in key.split('/'):
+        if isinstance(v, dict):
+            v = v.get(p, {})
+        else:
+            return ""
+    return v if isinstance(v, str) else ""
+
+
+def _get_client():
+    api_key = _vget("composio/api_key")
+    if not api_key:
+        return None, "API-Key fehlt. Trage ihn unter Integrationen > Composio ein."
+    try:
+        from composio import Composio
+        c = Composio(api_key=api_key)
+        return c, None
+    except ImportError:
+        return None, "composio ist nicht installiert. pip install composio"
+    except Exception as e:
+        return None, str(e)
+
+
+def _get_entity_id():
+    return _vget("composio/user_id") or "default"
+
+
+def composio_list_toolkits(search=""):
+    client, err = _get_client()
+    if err:
+        return f"❌ {err}"
+    try:
+        result = client.toolkits.list()
+        items = result.items if hasattr(result, 'items') else (result or [])
+        if search:
+            s = search.lower()
+            items = [i for i in items if s in (i.name or "").lower() or s in (i.description or "").lower()]
+        if not items:
+            return "ℹ️ Keine Toolkits gefunden."
+        lines = [f"📦 **{len(items)} Apps/Toolkits**:"]
+        for i in sorted(items, key=lambda x: x.name):
+            auth = getattr(i, 'auth_scheme', None)
+            auth_str = " 🔑" if auth else ""
+            cats = getattr(i, 'categories', None) or []
+            cat_str = f" [{', '.join(cats[:3])}]" if cats else ""
+            desc = (getattr(i, 'description', '') or '')[:120]
+            lines.append(f"  **{i.name}**{auth_str}{cat_str}")
+            if desc:
+                lines.append(f"    {desc}")
+        return "\n".join(lines)
+    except Exception as e:
+        return f"❌ {e}"
+
+
+def composio_list_tools(app="", search="", limit=20):
+    client, err = _get_client()
+    if err:
+        return f"❌ {err}"
+    try:
+        kwargs = {"user_id": _get_entity_id(), "limit": min(limit, 50)}
+        if app:
+            kwargs["toolkits"] = [app]
+        if search:
+            kwargs["search"] = search
+        tools = client.tools.get(**kwargs)
+        if not tools:
+            return "ℹ️ Keine Tools gefunden."
+        if not isinstance(tools, list):
+            tools = [tools]
+        lines = [f"🔧 **{len(tools)} Tools**" + (f" für **{app}**" if app else "") + (f" zu '{search}'" if search else "") + ":"]
+        for t in tools[:limit]:
+            name = "?"
+            desc = ""
+            props = {}
+            if isinstance(t, dict):
+                fn = t.get("function", t)
+                name = fn.get("name", "?")
+                desc = (fn.get("description", "") or "")[:100]
+                params = fn.get("parameters", {})
+                props = params.get("properties", {}) if isinstance(params, dict) else {}
+            elif hasattr(t, "function"):
+                fn = t.function
+                name = getattr(fn, "name", "?")
+                desc = (getattr(fn, "description", "") or "")[:100]
+                p = getattr(fn, "parameters", {})
+                props = p.get("properties", {}) if isinstance(p, dict) else {}
+            app_name = app or "?"
+            lines.append(f"  **{name}**")
+            if desc:
+                lines.append(f"    {desc}")
+            lines.append(f"    App: {app_name} | Parameter: {len(props)}")
+        if len(tools) > limit:
+            lines.append(f"  … und {len(tools) - limit} weitere (erhöhe limit)")
+        return "\n".join(lines)
+    except Exception as e:
+        return f"❌ {e}"
+
+
+def composio_execute(slug, params="{}", connected_account_id=""):
+    client, err = _get_client()
+    if err:
+        return f"❌ {err}"
+    try:
+        if isinstance(params, str):
+            params = json.loads(params)
+        kwargs = {
+            "slug": slug,
+            "arguments": params,
+            "user_id": _get_entity_id(),
+        }
+        if connected_account_id:
+            kwargs["connected_account_id"] = connected_account_id
+        result = client.tools.execute(**kwargs)
+        data = result.data if hasattr(result, 'data') else result
+        if isinstance(data, dict) and "error" in data:
+            return f"❌ {data['error']}"
+        return json.dumps(data, ensure_ascii=False, indent=2, default=str)[:8000]
+    except Exception as e:
+        return f"❌ {e}"
+
+
+def composio_list_connections():
+    client, err = _get_client()
+    if err:
+        return f"❌ {err}"
+    try:
+        result = client.connected_accounts.list()
+        items = result.items if hasattr(result, 'items') else (result or [])
+        if not items:
+            return "ℹ️ Keine verbundenen Konten."
+        lines = [f"🔗 **{len(items)} Verbindungen**:"]
+        for conn in items:
+            status = getattr(conn, 'status', 'UNKNOWN')
+            status_icon = "✅" if status == "ACTIVE" else "❌"
+            app_name = getattr(conn, 'appName', '?')
+            conn_id = getattr(conn, 'id', '?')
+            lines.append(f"  {status_icon} **{app_name}** (`{conn_id}`) – {status}")
+        return "\n".join(lines)
+    except Exception as e:
+        return f"❌ {e}"
+
+
+def composio_initiate_connection(app_name):
+    client, err = _get_client()
+    if err:
+        return f"❌ {err}"
+    try:
+        entity_id = _get_entity_id()
+        # Get toolkit info to find auth config
+        toolkit = client.toolkits.get(slug=app_name)
+        auth_config_id = None
+        if hasattr(toolkit, 'auth_schemes') and toolkit.auth_schemes:
+            auth_config_id = toolkit.auth_schemes[0].get('auth_config_id') if isinstance(toolkit.auth_schemes[0], dict) else getattr(toolkit.auth_schemes[0], 'auth_config_id', None)
+        if not auth_config_id:
+            # Fallback: try passing app_name as auth_config_id
+            auth_config_id = app_name
+        connection_request = client.connected_accounts.initiate(
+            user_id=entity_id,
+            auth_config_id=auth_config_id,
+        )
+        redirect_url = getattr(connection_request, 'redirectUrl', None) or getattr(connection_request, 'redirect_url', None)
+        if redirect_url:
+            return (
+                f"🌐 Öffne diesen Link um **{app_name}** zu verbinden:\n"
+                f"{redirect_url}\n\n"
+                f"Nach der Autorisierung kannst du Composio-Tools für {app_name} nutzen.\n"
+                f"Verwende composio_list_connections() um den Status zu prüfen."
+            )
+        return f"✅ **{app_name}** wurde verbunden (kein OAuth nötig)."
+    except Exception as e:
+        return f"❌ {e}"
+
+
+TOOLS = [
+    {"type": "function", "function": {"name": "composio_list_apps", "description": "List all available apps/toolkits available via Composio. Optionally filter by search term.", "parameters": {"type": "object", "properties": {"search": {"type": "string", "description": "Search term to filter (optional)"}}, "required": []}}},
+    {"type": "function", "function": {"name": "composio_list_toolkits", "description": "List all available apps/toolkits available via Composio. Optionally filter by search term.", "parameters": {"type": "object", "properties": {"search": {"type": "string", "description": "Search term to filter (optional)"}}, "required": []}}},
+    {"type": "function", "function": {"name": "composio_list_tools", "description": "List available tools/actions for a specific app or search for tools.", "parameters": {"type": "object", "properties": {"app": {"type": "string", "description": "App name (e.g. GITHUB, GMAIL, SLACK, NOTION)"}, "search": {"type": "string", "description": "Search term for use case"}, "limit": {"type": "integer", "description": "Maximum count (default 20, max 50)"}}, "required": []}}},
+    {"type": "function", "function": {"name": "composio_execute", "description": "Execute a Composio tool. Tools follow the pattern APP_ACTION (e.g. GITHUB_LIST_STARGAZERS, GMAIL_SEND_EMAIL). Use composio_list_tools() first to discover available tools and their parameters.", "parameters": {"type": "object", "properties": {"slug": {"type": "string", "description": "Tool slug (e.g. GITHUB_LIST_ISSUES, GMAIL_SEND_EMAIL)"}, "params": {"type": "string", "description": "JSON string with parameters. Must match the tool's input schema."}, "connected_account_id": {"type": "string", "description": "Connected account ID (optional, if not the default one)"}}, "required": ["slug", "params"]}}},
+    {"type": "function", "function": {"name": "composio_list_connections", "description": "List all active connected accounts.", "parameters": {"type": "object", "properties": {}, "required": []}}},
+    {"type": "function", "function": {"name": "composio_initiate_connection", "description": "Start the OAuth connection process for an app (e.g. GITHUB, GMAIL). Returns a link to authorize.", "parameters": {"type": "object", "properties": {"app_name": {"type": "string", "description": "App name (e.g. GITHUB, GMAIL, SLACK, NOTION, LINEAR, JIRA)"}}, "required": ["app_name"]}}},
+]
+
+TOOL_MAP = {
+    "composio_list_apps": composio_list_toolkits,
+    "composio_list_toolkits": composio_list_toolkits,
+    "composio_list_tools": composio_list_tools,
+    "composio_execute": composio_execute,
+    "composio_list_connections": composio_list_connections,
+    "composio_initiate_connection": composio_initiate_connection,
+}
+
+PROMPT_EXTRA = (
+    "COMPOSIO (200+ App-Integrations):\n"
+    "  Composio provides connections to 200+ services (GitHub, Gmail, Slack, Notion, Linear, Jira, etc.).\n"
+    "  1. **composio_list_toolkits(search)**: Browse all available apps\n"
+    "  2. **composio_list_tools(app, search, limit)**: Show tools for an app\n"
+    "  3. **composio_execute(slug, params, connected_account_id)**: Execute a tool\n"
+    "  4. **composio_list_connections()**: Show connected accounts\n"
+    "  5. **composio_initiate_connection(app_name)**: Get OAuth link to connect an app\n"
+    "\n"
+    "  Tool slugs follow APP_ACTION pattern, e.g.:\n"
+    "    - GITHUB_LIST_ISSUES, GITHUB_CREATE_ISSUE, GITHUB_LIST_REPOS\n"
+    "    - GMAIL_SEND_EMAIL, GMAIL_LIST_THREADS, GMAIL_READ_EMAIL\n"
+    "    - SLACK_POST_MESSAGE, SLACK_LIST_CHANNELS\n"
+    "    - NOTION_CREATE_PAGE, NOTION_QUERY_DATABASE\n"
+    "\n"
+    "  IMPORTANT:\n"
+    "    - Call composio_list_tools() first to discover available tools\n"
+    "    - For authenticated tools, run composio_initiate_connection() first\n"
+    "    - Vault: composio/api_key (required), composio/user_id (optional)\n"
+    "    - After OAuth, use composio_list_connections() to verify\n"
+    "\n"
+    "  EXAMPLES:\n"
+    "    'What apps are available?' -> composio_list_toolkits()\n"
+    "    'List GitHub issues in ComposioHQ/composio' -> composio_list_tools(app='GITHUB', search='issues') -> composio_execute('GITHUB_LIST_ISSUES', '{\"owner\":\"ComposioHQ\",\"repo\":\"composio\"}')\n"
+    "    'Send an email to test@example.com' -> composio_list_tools(app='GMAIL', search='send') -> composio_execute('GMAIL_SEND_EMAIL', '{\"to\":\"test@example.com\",\"subject\":\"Hello\",\"body\":\"Test\"}')\n"
+    "    'Connect my GitHub account' -> composio_initiate_connection('GITHUB')\n"
+    "    'What is connected?' -> composio_list_connections()\n"
+)

--- a/data/plugins/email.py
+++ b/data/plugins/email.py
@@ -76,6 +76,7 @@ def _connect_smtp(account="default"):
     return s, None
 
 def email_search(query="ALL", mailbox="INBOX", max_results=20, account="default"):
+    c = None
     try:
         c, err = _connect_imap(account)
         if err:
@@ -90,10 +91,15 @@ def email_search(query="ALL", mailbox="INBOX", max_results=20, account="default"
             if d[0][1]:
                 msg = eml.message_from_bytes(d[0][1])
                 results.append(f"ID:{mid.decode()} | {account} | {msg['Date']} | {msg['From']} | {msg['Subject']}")
-        c.logout()
         return '\n'.join(results) if results else "(keine)"
     except Exception as e:
         return f"❌ {e}"
+    finally:
+        if c:
+            try:
+                c.logout()
+            except Exception:
+                pass
 
 def email_read(mail_id, mailbox="INBOX", account="default"):
     c = None
@@ -144,7 +150,7 @@ def email_send(to, subject, body, cc="", bcc="", account="default"):
         if cc:
             msg['Cc'] = cc
         msg.attach(MIMEText(body, 'plain', 'utf-8'))
-        all_recip = [to] + ([cc] if cc else [])
+        all_recip = [to] + ([cc] if cc else []) + ([bcc] if bcc else [])
         s.sendmail(user, all_recip, msg.as_string())
         return f"✅ Email an {to} gesendet (Konto: {account}): {subject}"
     except Exception as e:
@@ -170,7 +176,6 @@ def email_get_unread_count(mailbox="INBOX", account="default"):
         ids = data[0].split() if data[0] else []
         _, total_data = c.search(None, "ALL")
         total = total_data[0].split() if total_data[0] else []
-        c.logout()
         return f" {account}/{mailbox}: {len(ids)} ungelesen von {len(total)} gesamt"
     except Exception as e:
         return f"❌ {e}"
@@ -224,9 +229,7 @@ def email_move_message(mail_id, from_mailbox="INBOX", to_mailbox="", account="de
         if r[0] == "OK":
             c.store(mail_id.encode(), "+FLAGS", "\\Deleted")
             c.expunge()
-            c.logout()
             return f"✅ {mail_id} von {from_mailbox} nach {to_mailbox} verschoben"
-        c.logout()
         return f"❌ Kopieren fehlgeschlagen: {r}"
     except Exception as e:
         return f"❌ {e}"

--- a/frontend/app/guide/page.js
+++ b/frontend/app/guide/page.js
@@ -42,6 +42,9 @@ const SECTIONS = [
   { id: 'browser', icon: 'fa-globe',
     title_de: 'Browser', title_en: 'Browser',
     desc_de: 'Web-Recherche, Screenshots, Formulare.', desc_en: 'Web research, screenshots, forms.' },
+  { id: 'composio', icon: 'fa-puzzle-piece',
+    title_de: 'Composio (200+ Apps)', title_en: 'Composio (200+ Apps)',
+    desc_de: 'GitHub, Gmail, Slack, Notion, Linear, Jira uvm.', desc_en: 'GitHub, Gmail, Slack, Notion, Linear, Jira and more.' },
 ];
 
 export default function GuidePage() {
@@ -290,6 +293,19 @@ curl -fsSL https://ollama.com/install.sh | sh
             </div>
 
             <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Cloud-Modelle sind schneller und leistungsfähiger, aber Daten verlassen deine Infrastruktur. Lokale Modelle sind kostenlos und privat. Für Tool-Support wird Ollama 0.3.0+ benötigt.', 'Cloud models are faster and more capable, but data leaves your infrastructure. Local models are free and private. Tool support requires Ollama 0.3.0+.')}</span></div>
+
+            <h3>{t('Kostenlose / OpenAI-kompatible Endpoints', 'Free / OpenAI-compatible endpoints')}</h3>
+            <p>{t(
+              'Neben den kommerziellen Anbietern gibt es auch eine Reihe kostenloser oder kostengünstiger OpenAI-kompatibler APIs, die du als Base-URL in MYND eintragen kannst. Sobald du die Base-URL und den API-Key in Settings → AI hinterlegt hast, fragt MYND automatisch die verfügbaren Modelle ab — du musst den Modellnamen also nicht kennen.',
+              'Besides commercial providers, there are also several free or low-cost OpenAI-compatible APIs you can use as a Base URL in MYND. Once you enter the Base URL and API key in Settings → AI, MYND automatically fetches the available models — you do not need to know the model name in advance.'
+            )}</p>
+            <ul>
+              <li><strong>OpenRouter (kostenloser Tier):</strong> <code>https://openrouter.ai/api/v1</code> — {t('Zahlreiche Modelle auch kostenlos nutzbar (Ratenlimits).', 'Many models available for free (rate limited).')}</li>
+              <li><strong>Groq (kostenlos):</strong> <code>https://api.groq.com/openai</code> — {t('Llama-3.3-70B, Mixtral, Gemma-2. Kostenloser Tier mit Ratenlimit.', 'Llama-3.3-70B, Mixtral, Gemma-2. Free tier with rate limits.')}</li>
+              <li><strong>Google Gemini (kostenlos):</strong> <code>https://generativelanguage.googleapis.com/v1beta/openai/</code> — {t('Gemini 2.0 Flash kostenlos, API-Key von Google AI Studio.', 'Gemini 2.0 Flash free, API key from Google AI Studio.')}</li>
+              <li><strong>GitHub Models (kostenlos):</strong> <code>https://models.inference.ai.azure.com</code> — {t('GPT-4o-mini, Llama, Qwen, Mistral kostenlos mit GitHub-Token.', 'GPT-4o-mini, Llama, Qwen, Mistral free with GitHub token.')}</li>
+              <li><strong>Cloudflare Workers AI:</strong> <code>https://api.cloudflare.com/client/v4</code> — {t('Llama, Qwen, DeepSeek über Cloudflare Workers AI.', 'Llama, Qwen, DeepSeek via Cloudflare Workers AI.')}</li>
+            </ul>
           </article>
 
           {/* Security & Modes */}
@@ -439,6 +455,52 @@ curl -fsSL https://ollama.com/install.sh | sh
               'Ask: "Open [URL]", "Take a screenshot of [URL]", "Summarize the content of [URL]", "Search the page for [query]".'
             )}</p>
             <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t('Der integrierte Browser läuft isoliert auf dem Server und teilt keine Cookies mit deinem lokalen Browser.', 'The built-in browser runs isolated on the server and does not share cookies with your local browser.')}</span></div>
+          </article>
+
+          {/* Composio */}
+          <article className="lp-guide-section" id="composio">
+            <h2><i className="fas fa-puzzle-piece" /> {t('Composio (200+ Apps)', 'Composio (200+ Apps)')}</h2>
+            <p>{t(
+              'Composio ist eine Cloud-Plattform, die 200+ App-Integrationen für KI-Agenten bereitstellt – darunter GitHub, Gmail, Slack, Notion, Linear, Jira, Google Drive, Asana, und viele mehr. MYND nutzt Composio als Gateway: Du verbindest deine Dienste einmalig per OAuth, und die KI kann dann Tasks ausführen wie Issues erstellen, E-Mails senden oder Slack-Nachrichten schreiben.',
+              'Composio is a cloud platform providing 200+ app integrations for AI agents — including GitHub, Gmail, Slack, Notion, Linear, Jira, Google Drive, Asana, and many more. MYND uses Composio as a gateway: you connect your services once via OAuth, and the AI can perform tasks like creating issues, sending emails, or posting Slack messages.'
+            )}</p>
+            <h3>{t('1. Composio-Konto erstellen', '1. Create Composio account')}</h3>
+            <p>{t(
+              'Gehe auf https://composio.dev und registriere dich. Nach dem Login findest du unter "Settings" deinen API-Key. Kopiere diesen.',
+              'Go to https://composio.dev and sign up. After logging in, find your API key under "Settings". Copy it.'
+            )}</p>
+            <h3>{t('2. API-Key in MYND hinterlegen', '2. Store API key in MYND')}</h3>
+            <p>{t(
+              'Settings → Integrationen → "Composio (200+ Apps)". API-Key eingeben und im Tresor speichern. Optional: User-ID auf "default" lassen oder eine eigene ID vergeben.',
+              'Settings → Integrations → "Composio (200+ Apps)". Enter the API key and save to vault. Optional: leave User-ID as "default" or set your own.'
+            )}</p>
+            <h3>{t('3. App verbinden (OAuth)', '3. Connect an app (OAuth)')}</h3>
+            <p>{t(
+              'Sage der KI: "Verbinde mein GitHub-Konto" oder "Connect my Gmail". Die KI wird dir einen OAuth-Link geben. Öffne den Link in deinem Browser und autorisiere die App. Nach erfolgreicher Verbindung kannst du die App sofort nutzen.',
+              'Tell the AI: "Verbinde mein GitHub-Konto" or "Connect my Gmail". The AI will provide an OAuth link. Open the link in your browser and authorize the app. Once connected, you can use it immediately.'
+            )}</p>
+            <h3>{t('4. Nutzung', '4. Usage')}</h3>
+            <p>{t(
+              'Nach der Verbindung kann die KI Aufträge ausführen wie:',
+              'Once connected, the AI can carry out tasks such as:'
+            )}</p>
+            <ul>
+              <li>{t('"Liste die offenen Issues in meinem Repository"', '"List open issues in my repository"')}</li>
+              <li>{t('"Erstelle ein neues GitHub Issue"', '"Create a new GitHub issue"')}</li>
+              <li>{t('"Such in meinem Gmail-Postfach nach Rechnungen"', '"Search my Gmail inbox for invoices"')}</li>
+              <li>{t('"Schreib eine Slack-Nachricht in #allgemein"', '"Send a Slack message to #general"')}</li>
+              <li>{t('"Erstelle eine neue Notion-Seite mit Meeting-Notes"', '"Create a new Notion page with meeting notes"')}</li>
+              <li>{t('"Zeig mir meine Linear-Tickets"', '"Show me my Linear tickets"')}</li>
+            </ul>
+            <div className="lp-guide-tip"><i className="fas fa-lightbulb" /><span>{t(
+              'Composio erfordert einen API-Key von composio.dev (kostenlose Stufe verfügbar). Die OAuth-Verbindungen werden in der Composio-Cloud gespeichert, nicht lokal. Für die erstmalige Einrichtung ist ein Internetzugang erforderlich.',
+              'Composio requires an API key from composio.dev (free tier available). OAuth connections are stored in the Composio cloud, not locally. Internet access is required for initial setup.'
+            )}</span></div>
+            <h3>{t('Verfügbare Tools im Überblick', 'Available tools overview')}</h3>
+            <p>{t(
+              'Die KI kann jederzeit mit composio_list_apps() alle verfügbaren Apps abfragen. Mit composio_list_tools(app="GITHUB") siehst du die konkreten Aktionen einer App. Die Tool-Slugs folgen dem Muster APP_ACTION (z.B. GITHUB_CREATE_ISSUE, GMAIL_SEND_EMAIL, SLACK_POST_MESSAGE).',
+              'The AI can query all available apps at any time with composio_list_apps(). Use composio_list_tools(app="GITHUB") to see specific actions for an app. Tool slugs follow the pattern APP_ACTION (e.g. GITHUB_CREATE_ISSUE, GMAIL_SEND_EMAIL, SLACK_POST_MESSAGE).'
+            )}</p>
           </article>
 
           <footer className="lp-guide-article-footer">

--- a/frontend/components/settings/ConfigTab.js
+++ b/frontend/components/settings/ConfigTab.js
@@ -267,6 +267,7 @@ export default function ConfigTab({ tr, language }) {
         if (typeof window !== 'undefined') window.localStorage.setItem(TTS_PROVIDER_STORAGE_KEY, pTts);
         setGeminiTtsApiKey('');
         setGeminiTtsApiKeySet(Boolean(data?.gemini_tts_api_key_set || geminiTtsApiKeySet || geminiTtsApiKey.trim()));
+        loadOllamaModels();
         loadEmbeddingStatus();
       } else {
         setAiStatus(`Error: ${data?.error || tr('Fehler beim Speichern', 'Error saving')}`);
@@ -444,10 +445,16 @@ export default function ConfigTab({ tr, language }) {
         )}
         <div className="input-group">
           <label>{tr('Chat-/KI-Modell', 'Chat / AI model')}</label>
-          <select value={aiModel} onChange={(e) => setAiModel(e.target.value)}>
-            <option value="">{tr('Modell auswählen...', 'Select model...')}</option>
-            {aiModelOptions.map(model => <option key={model} value={model}>{model}</option>)}
-          </select>
+          <div style={{display: 'flex', gap: 6}}>
+            <select value={aiModel} onChange={(e) => setAiModel(e.target.value)} style={{flex: 1}}>
+              <option value="">{tr('Modell auswählen...', 'Select model...')}</option>
+              {aiModelOptions.map(model => <option key={model} value={model}>{model}</option>)}
+            </select>
+            <button className="btn secondary" onClick={loadOllamaModels} title={tr('Modelle neu abrufen', 'Refresh models')}
+              style={{padding: '0 12px', whiteSpace: 'nowrap', fontSize: '0.8rem', display: 'flex', alignItems: 'center', gap: 4}}>
+              <i className="fas fa-rotate" /> {tr('Neu laden', 'Refresh')}
+            </button>
+          </div>
         </div>
         <div className="input-group">
           <label>{tr('Embedding-Modell', 'Embedding model')}</label>

--- a/frontend/components/settings/IntegrationsTab.js
+++ b/frontend/components/settings/IntegrationsTab.js
@@ -10,6 +10,8 @@ const INTEGRATIONS = [
   { id: 'homeassistant', icon: 'fas fa-home',           labelDe: 'Home Assistant',      labelEn: 'Home Assistant' },
   { id: 'truenas',       icon: 'fas fa-server',         labelDe: 'TrueNAS',             labelEn: 'TrueNAS' },
   { id: 'server',        icon: 'fas fa-terminal',       labelDe: 'Server (SSH)',        labelEn: 'Server (SSH)' },
+  { id: 'affine',        icon: 'fas fa-layer-group',    labelDe: 'AFFiNE (Wissensdatenbank)', labelEn: 'AFFiNE (Knowledge Base)' },
+  { id: 'composio',      icon: 'fas fa-puzzle-piece',   labelDe: 'Composio (200+ Apps)',labelEn: 'Composio (200+ Apps)' },
   { id: 'spotify',       icon: 'fab fa-spotify',        labelDe: 'Spotify',             labelEn: 'Spotify' },
   { id: 'discord',       icon: 'fab fa-discord',        labelDe: 'Discord',             labelEn: 'Discord' },
   { id: 'plugins',       icon: 'fas fa-puzzle-piece',   labelDe: 'Plugin Manager',      labelEn: 'Plugin Manager' },
@@ -49,6 +51,15 @@ const FIELD_DEFS = {
     { key: 'server/user', labelDe: 'Server Benutzer', labelEn: 'Server User', type: 'text', placeholder: 'root' },
     { key: 'server/password', labelDe: 'Server Passwort', labelEn: 'Server Password', type: 'password' },
     { key: 'server/port', labelDe: 'Server Port', labelEn: 'Server Port', type: 'text', default: '22' },
+  ],
+  affine: [
+    { key: 'affine/domain', labelDe: 'AFFiNE Domain', labelEn: 'AFFiNE Domain', type: 'text', placeholder: 'https://affine.example.com' },
+    { key: 'affine/email',  labelDe: 'AFFiNE E-Mail',  labelEn: 'AFFiNE Email',  type: 'text' },
+    { key: 'affine/password', labelDe: 'AFFiNE Passwort', labelEn: 'AFFiNE Password', type: 'password' },
+  ],
+  composio: [
+    { key: 'composio/api_key', labelDe: 'Composio API-Key', labelEn: 'Composio API Key', type: 'password' },
+    { key: 'composio/user_id', labelDe: 'User-ID (optional)', labelEn: 'User ID (optional)', type: 'text', placeholder: 'default' },
   ],
   spotify: [
     { key: 'spotify/client_id',     labelDe: 'Client-ID',          labelEn: 'Client ID',          type: 'text' },
@@ -252,7 +263,7 @@ export default function IntegrationsTab({ tr, language }) {
     );
   }
 
-  const hasTest = ['immich', 'nextcloud', 'homeassistant', 'truenas', 'spotify', 'discord'].includes(activeInt);
+  const hasTest = ['immich', 'nextcloud', 'homeassistant', 'truenas', 'spotify', 'discord', 'composio', 'affine'].includes(activeInt);
 
   return (
     <div className="settings-panel" style={{ padding: 0, overflow: 'hidden', height: '100%', display: 'flex', flexDirection: 'column' }}>
@@ -276,7 +287,13 @@ export default function IntegrationsTab({ tr, language }) {
             {t(intLabel?.labelDe, intLabel?.labelEn)}
           </div>
           <p style={{ fontSize: '0.85rem', color: 'var(--muted)', marginBottom: '1.25rem' }}>
-            {activeInt === 'spotify'
+            {activeInt === 'affine'
+              ? t('Verbinde deine AFFiNE-Instanz (self-hosted). Die KI kann dann deine Dokumente durchsuchen und darauf basierend antworten.',
+                 'Connect your AFFiNE instance (self-hosted). The AI can search your documents and answer based on them.')
+              : activeInt === 'composio'
+              ? t('Composio bietet 200+ Integrationen (GitHub, Gmail, Slack, Notion, Linear, Jira, etc.). API-Key von composio.dev eintragen.',
+                 'Composio provides 200+ integrations (GitHub, Gmail, Slack, Notion, Linear, Jira, etc.). Enter your API key from composio.dev.')
+              : activeInt === 'spotify'
               ? t('Benötigt eine Spotify App im Developer Dashboard. Client-ID und -Secret eintragen, dann Authorization Code Grant durchführen.',
                  'Requires a Spotify App in the Developer Dashboard. Enter Client ID and Secret, then perform Authorization Code Grant.')
               : activeInt === 'discord'

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -39,3 +39,4 @@ APScheduler>=3.10.0
 
 # OAuth / Auth
 requests-oauthlib>=2.0.0
+composio-core>=0.7.0


### PR DESCRIPTION
## Änderungen

### AFFiNE (Wissensdatenbank)
- Volltext-Suche (`affine_search_content`) mit Snippet-Vorschau
- Metadaten pro Seite (`affine_get_page_metadata`)
- Seiten-Hierarchie als Block-Baum (`affine_page_hierarchy`)
- Workspace-Info mit Mitgliedern/Speicher (`affine_workspace_info`)
- Reichere Formatierung: # für Headings, - für Listen, Code-Blöcke
- Content-Cache mit Yjs-Größen-Invalidierung
- **Knowledge-Base-Integration**: `affine_index_all()` embeded AFFiNE in chunks.json → `search_documents()` findet AFFiNE-Inhalte
- Session-Reuse + Rate-Limit-Retry (429)
- KI sucht immer zuerst in AFFiNE vor Internet

### Composio
- Plugin für SDK v0.18.0 umgeschrieben
- Tool-Namen-Parsing im OpenAI-Format gefixt
- Test-Endpoint mit präziser Fehlererkennung

### Email
- BCC-Parameter wird jetzt gesendet
- Connection-Leaks behoben (finally-Blöcke)
- Double-Logouts entfernt

### Allgemein
- PROMPT_EXTRA für AFFiNE + Composio in helpers.py eingebunden