### PR TITLE
fix: Auto-Dark-Mode + Ollama 410 Gone handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/app/ollama_client.py
+++ b/app/ollama_client.py
@@ -48,6 +48,7 @@ class OllamaClient:
             "model": self.model,
             "messages": msgs,
             "stream": False,
+            "keep_alive": os.getenv('OLLAMA_KEEP_ALIVE', '30m'),
             "options": {"temperature": 0.1, "max_tokens": 2048}
         }
 
@@ -60,6 +61,13 @@ class OllamaClient:
                 gr.raise_for_status()
                 gd = gr.json()
                 return {"message": {"role": "assistant", "content": gd.get("response", "")}}
+            if resp.status_code == 410:
+                # Modell wurde entladen – einmalig neu laden und erneut versuchen.
+                retry = requests.post(url, json=payload, timeout=120)
+                if retry.status_code == 410:
+                    return {"error": "Ollama hat das Modell entladen (410 Gone) – bitte erneut versuchen."}
+                retry.raise_for_status()
+                return retry.json()
             resp.raise_for_status()
             return resp.json()
         except requests.exceptions.RequestException as e:

--- a/core/llm.py
+++ b/core/llm.py
@@ -15,6 +15,10 @@ RETRY_BASE_DELAY = 1.0
 RETRY_MAX_DELAY = 60.0
 
 
+def _keep_alive():
+    return os.getenv('OLLAMA_KEEP_ALIVE', '30m')
+
+
 def _retry_with_backoff(func, *args, **kwargs):
     for attempt in range(RETRY_MAX_ATTEMPTS):
         try:
@@ -27,7 +31,8 @@ def _retry_with_backoff(func, *args, **kwargs):
             time.sleep(delay)
         except requests.RequestException as e:
             status = e.response.status_code if e.response is not None else None
-            if status in (429, 500, 502, 503):
+            # 410 Gone: Ollama hat das Modell entladen – erneuter Versuch lädt es neu.
+            if status in (410, 429, 500, 502, 503):
                 if attempt == RETRY_MAX_ATTEMPTS - 1:
                     raise
                 delay = min(RETRY_BASE_DELAY * (2 ** attempt), RETRY_MAX_DELAY)
@@ -96,6 +101,7 @@ def chat_with_tools(model, msgs, tools):
         low_temp_models = [m.strip() for m in os.getenv('LOW_TEMP_MODELS', 'minimax-m2.5:cloud').split(',') if m.strip()]
         if model in low_temp_models:
             body.setdefault("options", {})["temperature"] = 0.3
+        body["keep_alive"] = _keep_alive()
 
         def _do_request():
             r = requests.post(f"{OLLAMA}/api/chat", json=body, timeout=300)
@@ -107,6 +113,13 @@ def chat_with_tools(model, msgs, tools):
         return {"error": "Ollama-Timeout – das Modell hat nicht rechtzeitig geantwortet."}
     except requests.exceptions.ConnectionError:
         return {"error": "Ollama nicht erreichbar – bitte prüfe ob 'ollama serve' läuft."}
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code if e.response is not None else None
+        if status == 410:
+            return {"error": "Ollama hat das Modell entladen (410 Gone) – bitte erneut versuchen oder 'ollama pull " + model + "' ausführen."}
+        if status == 404:
+            return {"error": f"Modell '{model}' nicht gefunden – bitte in Ollama importieren ('ollama pull {model}')."}
+        return {"error": f"LLM-Fehler (HTTP {status}): {e}"}
     except Exception as e:
         return {"error": f"LLM-Fehler: {e}"}
 
@@ -171,6 +184,7 @@ def chat_with_tools_stream(model, msgs, tools):
         low_temp_models = [m.strip() for m in os.getenv('LOW_TEMP_MODELS', 'minimax-m2.5:cloud').split(',') if m.strip()]
         if model in low_temp_models:
             body.setdefault("options", {})["temperature"] = 0.3
+        body["keep_alive"] = _keep_alive()
 
         def _do_request():
             r = requests.post(f"{OLLAMA}/api/chat", json=body, timeout=300, stream=True)
@@ -223,6 +237,14 @@ def chat_with_tools_stream(model, msgs, tools):
         yield "", "", {"error": "Ollama-Timeout – das Modell hat nicht rechtzeitig geantwortet."}
     except requests.exceptions.ConnectionError:
         yield "", "", {"error": "Ollama nicht erreichbar – bitte prüfe ob 'ollama serve' läuft."}
+    except requests.exceptions.HTTPError as e:
+        status = e.response.status_code if e.response is not None else None
+        if status == 410:
+            yield "", "", {"error": "Ollama hat das Modell entladen (410 Gone) – bitte erneut versuchen oder 'ollama pull " + model + "' ausführen."}
+        elif status == 404:
+            yield "", "", {"error": f"Modell '{model}' nicht gefunden – bitte in Ollama importieren ('ollama pull {model}')."}
+        else:
+            yield "", "", {"error": f"LLM-Fehler (HTTP {status}): {e}"}
     except Exception as e:
         yield "", "", {"error": f"LLM-Fehler: {e}"}
 

--- a/frontend/app/guide/page.js
+++ b/frontend/app/guide/page.js
@@ -54,7 +54,10 @@ export default function GuidePage() {
 
   useEffect(() => {
     const mode = (() => { try { return localStorage.getItem('darkMode') || 'light'; } catch { return 'light'; } })();
-    document.documentElement.setAttribute('data-mode', mode);
+    const resolved = mode === 'auto'
+      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : mode;
+    document.documentElement.setAttribute('data-mode', resolved);
     const observer = new IntersectionObserver(
       entries => { for (const e of entries) { if (e.isIntersecting) { setActiveId(e.target.id); break; } } },
       { rootMargin: '-100px 0px -66% 0px' }

--- a/frontend/components/LandingPage.js
+++ b/frontend/components/LandingPage.js
@@ -169,7 +169,10 @@ export default function LandingPage() {
       if (LANGUAGES.includes(stored)) setLang(stored);
     } catch {}
     const mode = (() => { try { return localStorage.getItem('darkMode') || 'light'; } catch(e) { return 'light'; } })();
-    document.documentElement.setAttribute('data-mode', mode);
+    const resolved = mode === 'auto'
+      ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+      : mode;
+    document.documentElement.setAttribute('data-mode', resolved);
   }, []);
 
   useEffect(() => {

--- a/frontend/hooks/useTheme.js
+++ b/frontend/hooks/useTheme.js
@@ -2,74 +2,74 @@
 
 import { useState, useEffect } from 'react';
 
-function loadTheme() {
-  if (typeof window === 'undefined') return { theme: 'gold', darkMode: 'light', contrastColor: '' };
-  const savedTheme = localStorage.getItem('theme') || 'gold';
-  const savedDarkMode = localStorage.getItem('darkMode') || 'light';
-  const savedContrast = localStorage.getItem('contrastColor') || '';
+function readStored() {
+  let theme = 'gold';
+  let darkMode = 'light';
+  let contrastColor = '';
   try {
-    document.documentElement.setAttribute('data-theme', savedTheme);
-    document.documentElement.setAttribute('data-mode', savedDarkMode);
-    if (savedContrast) {
-      document.documentElement.style.setProperty('--brand', savedContrast);
-    }
+    theme = localStorage.getItem('theme') || 'gold';
+    darkMode = localStorage.getItem('darkMode') || 'light';
+    contrastColor = localStorage.getItem('contrastColor') || '';
   } catch {}
-  return { theme: savedTheme, darkMode: savedDarkMode, contrastColor: savedContrast };
+  return { theme, darkMode, contrastColor };
+}
+
+function resolveMode(mode) {
+  if (mode === 'auto') {
+    if (typeof window === 'undefined') return 'light';
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return mode;
+}
+
+function applyTheme({ theme, darkMode, contrastColor }) {
+  if (typeof document === 'undefined') return;
+  document.documentElement.setAttribute('data-theme', theme);
+  document.documentElement.setAttribute('data-mode', resolveMode(darkMode));
+  if (contrastColor) {
+    document.documentElement.style.setProperty('--brand', contrastColor);
+  } else {
+    document.documentElement.style.removeProperty('--brand');
+  }
 }
 
 export function useTheme() {
-  const initial = loadTheme();
-  const [theme, setThemeState] = useState(initial.theme);
-  const [darkMode, setDarkModeState] = useState(initial.darkMode);
-  const [contrastColor, setContrastColorState] = useState(initial.contrastColor);
+  const [state, setState] = useState(readStored);
+  const { theme, darkMode, contrastColor } = state;
 
   useEffect(() => {
-  const savedDarkMode = localStorage.getItem('darkMode') || 'light';
-
-    applyDarkMode(savedDarkMode);
-
+    applyTheme({ theme, darkMode, contrastColor });
+    if (darkMode !== 'auto') return undefined;
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handleChange = () => {
-      if (savedDarkMode === 'auto') applyDarkMode('auto');
+      document.documentElement.setAttribute('data-mode', mediaQuery.matches ? 'dark' : 'light');
     };
     mediaQuery.addEventListener('change', handleChange);
     return () => mediaQuery.removeEventListener('change', handleChange);
-  }, []);
-
-  const applyDarkMode = (mode) => {
-    if (mode === 'auto') {
-      const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-      document.documentElement.setAttribute('data-mode', prefersDark ? 'dark' : 'light');
-    } else {
-      document.documentElement.setAttribute('data-mode', mode);
-    }
-  };
+  }, [theme, darkMode, contrastColor]);
 
   const setTheme = (newTheme) => {
-    setThemeState(newTheme);
-    localStorage.setItem('theme', newTheme);
-    document.documentElement.setAttribute('data-theme', newTheme);
-    
-    if (contrastColor) {
-      document.documentElement.style.setProperty('--brand', contrastColor);
-    } else {
-      document.documentElement.style.removeProperty('--brand');
-    }
+    const next = { ...state, theme: newTheme };
+    setState(next);
+    try { localStorage.setItem('theme', newTheme); } catch {}
+    applyTheme(next);
   };
 
   const setDarkMode = (mode) => {
-    setDarkModeState(mode);
-    localStorage.setItem('darkMode', mode);
-    applyDarkMode(mode);
+    const next = { ...state, darkMode: mode };
+    setState(next);
+    try { localStorage.setItem('darkMode', mode); } catch {}
+    applyTheme(next);
   };
 
   const setContrastColor = (color) => {
-    setContrastColorState(color);
+    const next = { ...state, contrastColor: color };
+    setState(next);
     if (color) {
-      localStorage.setItem('contrastColor', color);
+      try { localStorage.setItem('contrastColor', color); } catch {}
       document.documentElement.style.setProperty('--brand', color);
     } else {
-      localStorage.removeItem('contrastColor');
+      try { localStorage.removeItem('contrastColor'); } catch {}
       document.documentElement.style.removeProperty('--brand');
     }
   };

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -430,3 +430,53 @@ class TestModelWarmUp:
         assert t.daemon is True
         assert t.name == "model-warmup"
         t.join(timeout=0.1)
+
+class TestOllamaClient410:
+    def test_chat_retries_once_on_410(self, monkeypatch):
+        from app.ollama_client import OllamaClient
+
+        class _Resp:
+            def __init__(self, status, payload=None):
+                self.status_code = status
+                self._payload = payload or {}
+
+            def json(self):
+                return self._payload
+
+            def raise_for_status(self):
+                if self.status_code >= 400:
+                    import requests
+                    raise requests.exceptions.HTTPError(
+                        f"{self.status_code} Client Error", response=self
+                    )
+
+        calls = []
+
+        def fake_post(url, json=None, timeout=None):
+            calls.append(json)
+            if len(calls) == 1:
+                return _Resp(410)
+            return _Resp(200, {"message": {"role": "assistant", "content": "recovered"}})
+
+        monkeypatch.setattr("app.ollama_client.requests.post", fake_post)
+        client = OllamaClient(base_url="http://127.0.0.1:11434", model="gemma3")
+        result = client.chat([{"role": "user", "content": "hi"}])
+        assert len(calls) == 2
+        assert calls[0].get("keep_alive") == "30m"
+        assert result["message"]["content"] == "recovered"
+
+    def test_chat_410_twice_returns_friendly_error(self, monkeypatch):
+        from app.ollama_client import OllamaClient
+
+        class _Resp:
+            status_code = 410
+
+            def raise_for_status(self):
+                import requests
+                raise requests.exceptions.HTTPError("410 Client Error: Gone", response=self)
+
+        monkeypatch.setattr("app.ollama_client.requests.post", lambda *a, **k: _Resp())
+        client = OllamaClient(base_url="http://127.0.0.1:11434", model="gemma3")
+        result = client.chat([{"role": "user", "content": "hi"}])
+        assert result.get("error") and "entladen" in result["error"]
+

--- a/tests/test_core_llm.py
+++ b/tests/test_core_llm.py
@@ -130,6 +130,96 @@ class TestChatWithTools:
         called_json = mock_post.call_args[1]["json"]
         assert "options" not in called_json
 
+    @patch("core.llm._is_openai", return_value=False)
+    @patch("core.llm.requests.post")
+    def test_keep_alive_sent_to_ollama(self, mock_post, mock_is_openai):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"message": {"role": "assistant", "content": "ok"}}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        from core.llm import chat_with_tools
+        chat_with_tools("gemma3", [{"role": "user", "content": "hi"}], [])
+        called_json = mock_post.call_args[1]["json"]
+        assert called_json.get("keep_alive") == "30m"
+
+    @patch("core.llm._is_openai", return_value=False)
+    @patch("core.llm.requests.post")
+    def test_keep_alive_respects_env(self, mock_post, mock_is_openai):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"message": {"role": "assistant", "content": "ok"}}
+        mock_resp.raise_for_status.return_value = None
+        mock_post.return_value = mock_resp
+
+        from core.llm import chat_with_tools
+        with patch.dict("os.environ", {"OLLAMA_KEEP_ALIVE": "-1"}):
+            chat_with_tools("gemma3", [{"role": "user", "content": "hi"}], [])
+            called_json = mock_post.call_args[1]["json"]
+            assert called_json.get("keep_alive") == "-1"
+
+    @patch("core.llm._is_openai", return_value=False)
+    @patch("core.llm.requests.post")
+    def test_ollama_410_retries_then_friendly_error(self, mock_post, mock_is_openai):
+        import requests as _requests
+
+        from core.llm import RETRY_MAX_ATTEMPTS, chat_with_tools
+
+        def _make_410():
+            r = MagicMock()
+            r.status_code = 410
+            r.raise_for_status.side_effect = _requests.exceptions.HTTPError(
+                "410 Client Error: Gone", response=r
+            )
+            return r
+
+        mock_post.side_effect = [_make_410() for _ in range(RETRY_MAX_ATTEMPTS)]
+        with patch("core.llm.time.sleep"):
+            result = chat_with_tools("gemma3", [{"role": "user", "content": "hi"}], [])
+        assert "error" in result
+        assert "entladen" in result["error"] or "Gone" in result["error"]
+        assert mock_post.call_count == RETRY_MAX_ATTEMPTS
+
+    @patch("core.llm._is_openai", return_value=False)
+    @patch("core.llm.requests.post")
+    def test_ollama_410_recovers_on_retry(self, mock_post, mock_is_openai):
+        import requests as _requests
+
+        def _make_410():
+            r = MagicMock()
+            r.status_code = 410
+            r.raise_for_status.side_effect = _requests.exceptions.HTTPError(
+                "410 Client Error: Gone", response=r
+            )
+            return r
+
+        ok_resp = MagicMock()
+        ok_resp.json.return_value = {"message": {"role": "assistant", "content": "recovered"}}
+        ok_resp.raise_for_status.return_value = None
+
+        from core.llm import chat_with_tools
+        mock_post.side_effect = [_make_410(), ok_resp]
+        with patch("core.llm.time.sleep"):
+            result = chat_with_tools("gemma3", [{"role": "user", "content": "hi"}], [])
+        assert "message" in result
+        assert result["message"]["content"] == "recovered"
+
+    @patch("core.llm._is_openai", return_value=False)
+    @patch("core.llm.requests.post")
+    def test_ollama_404_returns_model_hint(self, mock_post, mock_is_openai):
+        import requests as _requests
+
+        r = MagicMock()
+        r.status_code = 404
+        r.raise_for_status.side_effect = _requests.exceptions.HTTPError(
+            "404 Client Error: Not Found", response=r
+        )
+
+        from core.llm import chat_with_tools
+        mock_post.side_effect = [r]
+        result = chat_with_tools("gemma3", [{"role": "user", "content": "hi"}], [])
+        assert "error" in result
+        assert "ollama pull" in result["error"]
+
 
 class TestChatWithToolsStream:
     @patch("core.llm.requests.post")
@@ -181,6 +271,26 @@ class TestChatWithToolsStream:
         from core.llm import chat_with_tools_stream
         events = list(chat_with_tools_stream("gemma3", [{"role": "user", "content": "hi"}], []))
         assert any("error" in e[2] for e in events if e[0] == "")
+
+    @patch("core.llm.requests.post")
+    @patch("core.llm._is_openai", return_value=False)
+    def test_ollama_stream_410_yields_friendly_error(self, mock_is_openai, mock_post):
+        import requests as _requests
+
+        r = MagicMock()
+        r.ok = False
+        r.status_code = 410
+        r.raise_for_status.side_effect = _requests.exceptions.HTTPError(
+            "410 Client Error: Gone", response=r
+        )
+
+        from core.llm import RETRY_MAX_ATTEMPTS, chat_with_tools_stream
+        mock_post.side_effect = [r] * RETRY_MAX_ATTEMPTS
+        with patch("core.llm.time.sleep"):
+            events = list(chat_with_tools_stream("gemma3", [{"role": "user", "content": "hi"}], []))
+        errors = [e[2]["error"] for e in events if e[0] == "" and isinstance(e[2], dict) and "error" in e[2]]
+        assert errors, "expected an error event"
+        assert "entladen" in errors[0] or "Gone" in errors[0]
 
     @patch("core.llm.requests.post")
     @patch("core.llm._load_openai_config")


### PR DESCRIPTION
Behebt zwei gemeldete Probleme:

**Auto-Dark-Mode (useTheme.js, LandingPage, guide):**
- `data-mode="auto"` wurde roh gesetzt – dafür gibt es keine CSS-Regel, daher fiel die App nach jedem Re-Render auf Light zurück. `auto` wird jetzt überall via `matchMedia` in dark/light aufgelöst.
- Media-Query-Listener hatte einen veralteten Closure-Wert von Mount und reagierte nach Moduswechsel nicht mehr auf OS-Theme-Änderungen. Listener wird jetzt pro Modus neu abonniert (nur bei `auto` aktiv).
- `readStored()` nur noch als Lazy-Initializer (keine DOM-Nebeneffekte während Render).

**Ollama 410 Gone:**
- 410 jetzt retrybar in `_retry_with_backoff` – entladenes Modell wird beim Retry neu geladen.
- `keep_alive` (Default `30m`, env `OLLAMA_KEEP_ALIVE`) auf `/api/chat`-Payloads in `core/llm.py` + `app/ollama_client.py`.
- Verständliche Fehlermeldungen statt `410 Client Error: Gone`: 'Ollama hat das Modell entladen' / 'ollama pull <model>' bei 404.

Tests: keep_alive, 410 Retry+Recovery, 410/404 Fehlermeldungen (sync+stream), OllamaClient 410.