### PR TITLE
fix: 401-Spam auf Briefing/Context-API-Calls

### DIFF
--- a/frontend/app/(main)/page.js
+++ b/frontend/app/(main)/page.js
@@ -524,7 +524,7 @@ export default function HomePage() {
   const loadProactiveBriefings = useCallback(async (force = false) => {
     try {
       const briefingUrl = force ? `${getApiBase()}/api/assistant/briefing/current?force=true` : `${getApiBase()}/api/assistant/briefing/current`;
-      const res = await fetch(briefingUrl);
+      const res = await apiFetch(briefingUrl);
       const data = await safeReadJson(res);
       if (!res.ok || data?.success === false) return;
       const items = Array.isArray(data?.items) ? data.items : [];

--- a/frontend/components/ContextDataCard.js
+++ b/frontend/components/ContextDataCard.js
@@ -119,7 +119,7 @@ export default function ContextDataCard({ card, language: uiLanguage, onQueryAct
       setLoading(true);
       setError('');
       try {
-        const res = await fetch(fetchUrl);
+        const res = await apiFetch(fetchUrl);
         const data = await res.json();
         if (!res.ok || data?.success === false) {
           throw new Error(data?.error || `Request failed with status ${res.status}`);
@@ -211,7 +211,7 @@ export default function ContextDataCard({ card, language: uiLanguage, onQueryAct
   };
 
   const refreshCurrent = async () => {
-    const res = await fetch(fetchUrl);
+    const res = await apiFetch(fetchUrl);
     const data = await res.json();
     if (!res.ok || data?.success === false) {
       throw new Error(data?.error || `Request failed with status ${res.status}`);


### PR DESCRIPTION
Das Dashboard rief `/api/assistant/briefing/current` (und ContextDataCard `/api/calendar/ui`, `/api/tasks/ui`) mit rohem `fetch()` auf – ohne Bearer-Token → jeder Poll lieferte 401 (Konsole-Spam). Auf `apiFetch()` umgestellt, das den gespeicherten Token einfügt und Auth-Expiry behandelt.