### PR TITLE
fix: fall back to configured model when requested model is unavailable

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -93,9 +93,9 @@ _MODELS_CACHE = {}
 _MODELS_TTL = 60  # seconds
 
 
-def _available_models():
+def _available_models(base_url):
     """Short-cached set of models currently known to Ollama."""
-    key = f"{ollama_client.base_url}:{ollama_client.model}"
+    key = base_url
     now = time.time()
     cached = _MODELS_CACHE.get(key)
     if cached and now - cached[1] < _MODELS_TTL:
@@ -105,19 +105,23 @@ def _available_models():
     return models
 
 
-def _resolve_active_model(requested):
+def _resolve_active_model(requested, cfg):
     """Use the requested model if it is actually available, else fall back to
-    the configured model. Prevents e.g. 410 Gone for retired/removed models."""
-    if not requested or requested == ollama_client.model:
-        return ollama_client.model
-    available = _available_models()
+    the configured model. Prevents e.g. 410 Gone for retired/removed models.
+    Only consults Ollama's model list for the ollama provider."""
+    configured = str(cfg.get('model') or ollama_client.model)
+    if not requested or requested == configured:
+        return configured
+    if cfg.get('provider') != 'ollama':
+        return requested
+    available = _available_models(str(cfg.get('base_url') or ollama_client.base_url))
     if available and requested in available:
         return requested
     logger.warning(
         'Requested model %r is not available – falling back to %r',
-        requested, ollama_client.model,
+        requested, configured,
     )
-    return ollama_client.model
+    return configured
 
 def _cached_tool_support(model, base_url):
     """Cached check_tool_support — avoids a live LLM round-trip on every request."""
@@ -580,8 +584,8 @@ def agent_query_stream():
         return jsonify({'success': False, 'error': 'No prompt'}), 400
     _store_credentials_from_message(prompt)
     base_prompt = _build_agent_system_prompt(prompt, language)
-    active_model = _resolve_active_model(requested_model)
     cfg = load_ai_config()
+    active_model = _resolve_active_model(requested_model, cfg)
 
     def _get_web_context_safe(query, max_results):
         try:
@@ -654,7 +658,8 @@ def agent_query():
     elif preferred_source == 'local':
         source_hint = "\n\n⚠️ Nur lokale Dokumente.\n"
     system_prompt = base_prompt + source_hint
-    active_model = _resolve_active_model(requested_model)
+    cfg = load_ai_config()
+    active_model = _resolve_active_model(requested_model, cfg)
     try:
         content, history, needs_input, research_stats = web_agent_loop(
             active_model, prompt, system_prompt, max_rounds=100, owner=request.current_user

--- a/app/routes.py
+++ b/app/routes.py
@@ -89,6 +89,36 @@ _TOOL_SUPPORT_CACHE = {}
 _TOOL_SUPPORT_TTL = 30 * 60  # seconds
 _NO_TOOL_MODEL_KEYWORDS = tuple(k.strip().lower() for k in os.getenv('NO_TOOL_MODEL_KEYWORDS', 'phi,tinyllama').split(',') if k.strip())
 
+_MODELS_CACHE = {}
+_MODELS_TTL = 60  # seconds
+
+
+def _available_models():
+    """Short-cached set of models currently known to Ollama."""
+    key = f"{ollama_client.base_url}:{ollama_client.model}"
+    now = time.time()
+    cached = _MODELS_CACHE.get(key)
+    if cached and now - cached[1] < _MODELS_TTL:
+        return cached[0]
+    models = set(ollama_client.list_models())
+    _MODELS_CACHE[key] = (models, now)
+    return models
+
+
+def _resolve_active_model(requested):
+    """Use the requested model if it is actually available, else fall back to
+    the configured model. Prevents e.g. 410 Gone for retired/removed models."""
+    if not requested or requested == ollama_client.model:
+        return ollama_client.model
+    available = _available_models()
+    if available and requested in available:
+        return requested
+    logger.warning(
+        'Requested model %r is not available – falling back to %r',
+        requested, ollama_client.model,
+    )
+    return ollama_client.model
+
 def _cached_tool_support(model, base_url):
     """Cached check_tool_support — avoids a live LLM round-trip on every request."""
     if any(k in str(model).lower() for k in _NO_TOOL_MODEL_KEYWORDS):
@@ -550,7 +580,7 @@ def agent_query_stream():
         return jsonify({'success': False, 'error': 'No prompt'}), 400
     _store_credentials_from_message(prompt)
     base_prompt = _build_agent_system_prompt(prompt, language)
-    active_model = requested_model or ollama_client.model
+    active_model = _resolve_active_model(requested_model)
     cfg = load_ai_config()
 
     def _get_web_context_safe(query, max_results):
@@ -624,7 +654,7 @@ def agent_query():
     elif preferred_source == 'local':
         source_hint = "\n\n⚠️ Nur lokale Dokumente.\n"
     system_prompt = base_prompt + source_hint
-    active_model = requested_model or ollama_client.model
+    active_model = _resolve_active_model(requested_model)
     try:
         content, history, needs_input, research_stats = web_agent_loop(
             active_model, prompt, system_prompt, max_rounds=100, owner=request.current_user

--- a/app/routes.py
+++ b/app/routes.py
@@ -110,6 +110,7 @@ def _resolve_active_model(requested, cfg):
     the configured model. Prevents e.g. 410 Gone for retired/removed models.
     Only consults Ollama's model list for the ollama provider."""
     configured = str(cfg.get('model') or ollama_client.model)
+    requested = str(requested) if requested else ''
     if not requested or requested == configured:
         return configured
     if cfg.get('provider') != 'ollama':

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -537,3 +537,13 @@ class TestResolveActiveModel:
         )
         assert app_routes._resolve_active_model("gpt-4o-mini", cfg) == "gpt-4o-mini"
 
+    def test_non_string_requested_model_is_coerced(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "ollama", "model": "gemma4:cloud", "base_url": "http://127.0.0.1:11434"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        monkeypatch.setattr(
+            app_routes.ollama_client, "list_models",
+            lambda: ["gemma3:latest", "123"],
+        )
+        assert app_routes._resolve_active_model(123, cfg) == "123"
+

--- a/tests/test_app_routes.py
+++ b/tests/test_app_routes.py
@@ -480,3 +480,60 @@ class TestOllamaClient410:
         result = client.chat([{"role": "user", "content": "hi"}])
         assert result.get("error") and "entladen" in result["error"]
 
+
+class TestResolveActiveModel:
+    def _clear_model_cache(self):
+        app_routes._MODELS_CACHE.clear()
+
+    def test_no_requested_model_uses_configured(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "ollama", "model": "gemma4:cloud", "base_url": "http://127.0.0.1:11434"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        assert app_routes._resolve_active_model("", cfg) == "gemma4:cloud"
+
+    def test_requested_equals_configured_short_circuits(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "ollama", "model": "gemma4:cloud", "base_url": "http://127.0.0.1:11434"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        assert app_routes._resolve_active_model("gemma4:cloud", cfg) == "gemma4:cloud"
+
+    def test_requested_available_is_used(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "ollama", "model": "gemma4:cloud", "base_url": "http://127.0.0.1:11434"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        monkeypatch.setattr(
+            app_routes.ollama_client, "list_models",
+            lambda: ["gemma3:latest", "qwen3.6:27b"],
+        )
+        assert app_routes._resolve_active_model("qwen3.6:27b", cfg) == "qwen3.6:27b"
+
+    def test_requested_missing_falls_back_to_configured(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "ollama", "model": "gemma4:cloud", "base_url": "http://127.0.0.1:11434"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        monkeypatch.setattr(
+            app_routes.ollama_client, "list_models",
+            lambda: ["gemma3:latest"],
+        )
+        assert app_routes._resolve_active_model("minimax-m2.5:cloud", cfg) == "gemma4:cloud"
+
+    def test_non_ollama_provider_never_consults_model_list(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "openai", "model": "gpt-4o", "base_url": "https://api.openai.com"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        monkeypatch.setattr(
+            app_routes.ollama_client, "list_models",
+            lambda: (_ for _ in ()).throw(AssertionError("list_models must not be called")),
+        )
+        assert app_routes._resolve_active_model("gpt-4o", cfg) == "gpt-4o"
+
+    def test_non_ollama_provider_requested_model_passed_through(self, monkeypatch):
+        self._clear_model_cache()
+        cfg = {"provider": "openai", "model": "gpt-4o", "base_url": "https://api.openai.com"}
+        monkeypatch.setattr(app_routes.ollama_client, "model", "gemma3:latest")
+        monkeypatch.setattr(
+            app_routes.ollama_client, "list_models",
+            lambda: (_ for _ in ()).throw(AssertionError("list_models must not be called")),
+        )
+        assert app_routes._resolve_active_model("gpt-4o-mini", cfg) == "gpt-4o-mini"
+


### PR DESCRIPTION
## Summary
Protects against **410 Gone / 404** errors when a frontend still requests a retired or removed Ollama model (e.g. `minimax-m2.5:cloud`, which Ollama retired on 2026-07-31).

## Changes
- `app/routes.py`: added `_available_models()` (60 s cached set from `ollama_client.list_models()`) and `_resolve_active_model(requested)` which uses the requested model only if it is actually available, otherwise falls back to the configured model.
- Wired into both `agent_query_stream` and `agent_query`.

## Testing
- `ruff check app/routes.py` clean
- `python3 -m pytest tests/test_app_routes.py -q` → 38 passed, 1 skipped